### PR TITLE
Better DLOG keys handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "algebra"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "algebra-derive",
  "byteorder",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "algebra-derive"
 version = "0.2.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -71,7 +71,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "bench-utils"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 
 [[package]]
 name = "bit-vec"
@@ -165,7 +165,7 @@ checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 [[package]]
 name = "cctp_primitives"
 version = "0.1.1"
-source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?branch=integration#740c1dadc1e3547d9834b3aeea75eea284c691c6"
+source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?branch=integration#bdcb6af5f0a12bd40cbcd04703062de74d13a360"
 dependencies = [
  "algebra",
  "bit-vec",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if",
 ]
@@ -349,7 +349,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "field-assembly"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "mince",
 ]
@@ -448,9 +448,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "lock_api"
@@ -496,9 +496,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "mince"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "quote",
  "syn",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "poly-commit"
@@ -631,14 +631,14 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitives"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "proof-systems"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "algebra",
  "radix_trie",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "r1cs-crypto"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "r1cs-std"
 version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#0b490fccfa6690ac14d0b4cb9357245c94569cfc"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=integration#8c56a3ea0db4d295f04fd164f3afa26c0983ec1c"
 dependencies = [
  "algebra",
  "derivative",
@@ -857,18 +857,18 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -930,9 +930,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-xid"
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/api/src/utils.rs
+++ b/api/src/utils.rs
@@ -215,11 +215,10 @@ pub(crate) fn parse_merkle_path_from_jobject<'a>(
     read_raw_pointer(&_env, t.j().unwrap() as *const GingerMHTPath)
 }
 
-pub(crate) fn cast_joption_to_rust_option<'a>(
+pub(crate) fn parse_joption_from_jobject<'a>(
     _env: &'a JNIEnv,
     obj: JObject<'a>,
     opt_name: &str,
-    _wrapped_obj_class_path: &str,
 ) -> Option<JObject<'a>> {
     // Parse Optional object
     let opt_object = _env
@@ -227,6 +226,15 @@ pub(crate) fn cast_joption_to_rust_option<'a>(
         .expect(format!("Should be able to get {} Optional", opt_name).as_str())
         .l()
         .unwrap();
+
+    // Cast it to Rust option
+    cast_joption_to_rust_option(_env, opt_object)
+}
+
+pub(crate) fn cast_joption_to_rust_option<'a>(
+    _env: &'a JNIEnv,
+    opt_object: JObject<'a>,
+) -> Option<JObject<'a>> {
 
     if !_env
         .call_method(opt_object, "isPresent", "()Z", &[])
@@ -240,7 +248,6 @@ pub(crate) fn cast_joption_to_rust_option<'a>(
             _env.call_method(
                 opt_object,
                 "get",
-                //format!("()L{};", wrapped_obj_class_path).as_str(),
                 "()Ljava/lang/Object;",
                 &[],
             )

--- a/demo-circuit/src/blaze_csw/constraints/mod.rs
+++ b/demo-circuit/src/blaze_csw/constraints/mod.rs
@@ -750,6 +750,7 @@ mod test {
         if !debug_only {
             let _ = load_g1_committer_key(MAX_SEGMENT_SIZE - 1);
             let ck_g1 = get_g1_committer_key(Some(SUPPORTED_SEGMENT_SIZE - 1)).unwrap();
+            assert_eq!(ck_g1.comm_key.len(), SUPPORTED_SEGMENT_SIZE);
 
             let setup_circuit = CeasedSidechainWithdrawalCircuit::get_instance_for_setup(num_commitment_hashes, num_custom_fields, constant.is_some());
             let params = CoboundaryMarlin::index(&ck_g1, setup_circuit.clone()).unwrap();

--- a/demo-circuit/src/naive_threshold_sig/mod.rs
+++ b/demo-circuit/src/naive_threshold_sig/mod.rs
@@ -598,6 +598,8 @@ mod test {
         //Return proof and public inputs if success
         let rng = &mut OsRng;
         let ck_g1 = get_g1_committer_key(Some(SUPPORTED_SEGMENT_SIZE - 1)).unwrap();
+        assert_eq!(ck_g1.comm_key.len(), SUPPORTED_SEGMENT_SIZE);
+
         match CoboundaryMarlin::prove(
             &index_pk,
             &ck_g1,
@@ -632,6 +634,8 @@ mod test {
 
         let _ = load_g1_committer_key(MAX_SEGMENT_SIZE - 1);
         let ck = get_g1_committer_key(Some(SUPPORTED_SEGMENT_SIZE - 1)).unwrap();
+        assert_eq!(ck.comm_key.len(), SUPPORTED_SEGMENT_SIZE);
+
         let circ = NaiveTresholdSignature::get_instance_for_setup(n, 1);
 
         let params = CoboundaryMarlin::index(&ck, circ).unwrap();

--- a/jni/src/main/java/com/horizen/cswnative/CswProof.java
+++ b/jni/src/main/java/com/horizen/cswnative/CswProof.java
@@ -13,6 +13,7 @@ public class CswProof {
         int rangeSize,
         int numCustomFields,
         boolean isConstantPresent,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         String verificationKeyPath,
         boolean zk,
@@ -27,6 +28,10 @@ public class CswProof {
      * @param rangeSize - number of blocks between `mcbScTxsComStart` and `mcbScTxsComEnd`
      * @param numCustomFields - exact number of custom fields the circuit must support
      * @param isConstantPresent - whether the circuit must support the presence of a constant
+     * @param segmentSize - the segment size to be used to generate (pk, vk). Must be smaller equal than
+     *                      the segment size passed to the ProvingSystem.generateDLogKeys() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
      * @param provingKeyPath - file path to which saving the proving key
      * @param verificationKeyPath - file path to which saving the verification key
      * @param maxProofPlusVkSize - maximum allowed size for proof + vk
@@ -39,6 +44,7 @@ public class CswProof {
         int rangeSize,
         int numCustomFields,
         boolean isConstantPresent,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         String verificationKeyPath,
         boolean zk,
@@ -48,8 +54,9 @@ public class CswProof {
     )
     {
         return nativeSetup(
-            psType, rangeSize, numCustomFields, isConstantPresent, provingKeyPath,
-            verificationKeyPath, zk, maxProofPlusVkSize, compressPk, compressVk
+            psType, rangeSize, numCustomFields, isConstantPresent, segmentSize,
+            provingKeyPath, verificationKeyPath, zk, maxProofPlusVkSize, compressPk,
+            compressVk
         );
     }
 
@@ -59,6 +66,10 @@ public class CswProof {
      * @param rangeSize - number of blocks between `mcbScTxsComStart` and `mcbScTxsComEnd`
      * @param numCustomFields - exact number of custom fields the circuit must support
      * @param isConstantPresent - whether the circuit must support the presence of a constant
+     * @param segmentSize - the segment size to be used to generate (pk, vk). Must be smaller equal than
+     *                      the segment size passed to the ProvingSystem.generateDLogKeys() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
      * @param provingKeyPath - file path to which saving the proving key. Proving key will be saved in compressed form.
      * @param verificationKeyPath - file path to which saving the verification key. Verification key will be saved in compressed form.
      * @param zk - used to estimate the proof and vk size, tells if the proof will be created using zk or not
@@ -70,6 +81,7 @@ public class CswProof {
         int rangeSize,
         int numCustomFields,
         boolean isConstantPresent,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         String verificationKeyPath,
         boolean zk,
@@ -77,12 +89,44 @@ public class CswProof {
     )
     {
         return nativeSetup(
-            psType, rangeSize, numCustomFields, isConstantPresent,
+            psType, rangeSize, numCustomFields, isConstantPresent, segmentSize,
             provingKeyPath, verificationKeyPath, zk, maxProofPlusVkSize, true, true
         );
     }
 
     /**
+     * Generate (provingKey, verificationKey) pair for this circuit.
+     * @param psType - proving system to be used
+     * @param rangeSize - number of blocks between `mcbScTxsComStart` and `mcbScTxsComEnd`
+     * @param numCustomFields - exact number of custom fields the circuit must support
+     * @param isConstantPresent - whether the circuit must support the presence of a constant
+     * @param segmentSize - the segment size to be used to generate (pk, vk). Must be smaller equal than
+     *                      the segment size passed to the ProvingSystem.generateDLogKeys() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
+     * @param provingKeyPath - file path to which saving the proving key. Proving key will be saved in compressed form.
+     * @param verificationKeyPath - file path to which saving the verification key. Verification key will be saved in compressed form.
+     * @param maxProofPlusVkSize - maximum allowed size for proof + vk, estimated assuming not to use zk property
+     * @return true if (pk, vk) generation and saving to file was successfull, false otherwise.
+     */
+    public static boolean setup(
+        ProvingSystemType psType,
+        int rangeSize,
+        int numCustomFields,
+        boolean isConstantPresent,
+        Optional<Integer> segmentSize,
+        String provingKeyPath,
+        String verificationKeyPath,
+        int maxProofPlusVkSize
+    )
+    {
+        return nativeSetup(
+            psType, rangeSize, numCustomFields, isConstantPresent, segmentSize,
+            provingKeyPath, verificationKeyPath, false, maxProofPlusVkSize, true, true
+        );
+    }
+
+        /**
      * Generate (provingKey, verificationKey) pair for this circuit.
      * @param psType - proving system to be used
      * @param rangeSize - number of blocks between `mcbScTxsComStart` and `mcbScTxsComEnd`
@@ -104,8 +148,8 @@ public class CswProof {
     )
     {
         return nativeSetup(
-            psType, rangeSize, numCustomFields, isConstantPresent, provingKeyPath,
-            verificationKeyPath, false, maxProofPlusVkSize, true, true
+            psType, rangeSize, numCustomFields, isConstantPresent, Optional.empty(),
+            provingKeyPath, verificationKeyPath, false, maxProofPlusVkSize, true, true
         );
     }
 
@@ -117,6 +161,7 @@ public class CswProof {
         WithdrawalCertificate lastWcert,
         CswUtxoProverData utxoData,
         CswFtProverData ftData,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         boolean checkProvingKey,
         boolean zk,
@@ -170,6 +215,10 @@ public class CswProof {
      *                   must be present too.
      * @param ftData - data required to prove withdraw of a FT. Must be empty if the prover wants to prove
      *                 withdraw of a SC utxo instead. If present, then sysData.mcbScTxsComEnd must be present too.
+     * @param segmentSize - the segment size to be used to create the proof.
+     *                      Must be equal to the one passed to the setup() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
      * @param provingKeyPath - file path from which reading the proving key
      * @param checkProvingKey - enable semantic checks on the proving key (WARNING: very expensive)
      * @param zk - if proof must be created using zk property or not
@@ -186,6 +235,7 @@ public class CswProof {
         Optional<WithdrawalCertificate> lastWcert,
         Optional<CswUtxoProverData> utxoData,
         Optional<CswFtProverData> ftData,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         boolean checkProvingKey,
         boolean zk,
@@ -198,7 +248,7 @@ public class CswProof {
         // Note: to avoid too much unpacking boilerplate Rust side, we pass the empty Optional instances as null pointer instead.
         return nativeCreateProof(
             rangeSize, numCustomFields, sysData, scId, lastWcert.orElse(null), utxoData.orElse(null), ftData.orElse(null),
-            provingKeyPath, checkProvingKey, zk, compressed_pk, compress_proof
+            segmentSize, provingKeyPath, checkProvingKey, zk, compressed_pk, compress_proof
         );
     }
 
@@ -215,6 +265,10 @@ public class CswProof {
      *                   must be present too.
      * @param ftData - data required to prove withdraw of a FT. Must be empty if the prover wants to prove
      *                 withdraw of a SC utxo instead. If present, then sysData.mcbScTxsComEnd must be present too.
+     * @param segmentSize - the segment size to be used to create the proof.
+     *                      Must be equal to the one passed to the setup() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
      * @param provingKeyPath - file path from which reading the proving key, expected to be in compressed form
      * @param checkProvingKey - enable semantic checks on the proving key (WARNING: very expensive)
      * @param zk - if proof must be created using zk property or not
@@ -229,6 +283,7 @@ public class CswProof {
         Optional<WithdrawalCertificate> lastWcert,
         Optional<CswUtxoProverData> utxoData,
         Optional<CswFtProverData> ftData,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         boolean checkProvingKey,
         boolean zk
@@ -239,7 +294,7 @@ public class CswProof {
         // Note: to avoid too much unpacking boilerplate Rust side, we pass the empty Optional instances as null pointer instead.
         return nativeCreateProof(
             rangeSize, numCustomFields, sysData, scId, lastWcert.orElse(null), utxoData.orElse(null), ftData.orElse(null),
-            provingKeyPath, checkProvingKey, zk, true, true
+            segmentSize, provingKeyPath, checkProvingKey, zk, true, true
         );
     }
 
@@ -256,6 +311,10 @@ public class CswProof {
      *                   must be present too.
      * @param ftData - data required to prove withdraw of a FT. Must be empty if the prover wants to prove
      *                 withdraw of a SC utxo instead. If present, then sysData.mcbScTxsComEnd must be present too.
+     * @param segmentSize - the segment size to be used to create the proof.
+     *                      Must be equal to the one passed to the setup() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
      * @param provingKeyPath - file path from which reading the proving key, expected to be in compressed form
      * @param zk - if proof must be created using zk property or not
      * @return the proof bytes
@@ -269,6 +328,7 @@ public class CswProof {
         Optional<WithdrawalCertificate> lastWcert,
         Optional<CswUtxoProverData> utxoData,
         Optional<CswFtProverData> ftData,
+        Optional<Integer> segmentSize,
         String provingKeyPath,
         boolean zk
     ) throws IllegalArgumentException 
@@ -278,11 +338,53 @@ public class CswProof {
         // Note: to avoid too much unpacking boilerplate Rust side, we pass the empty Optional instances as null pointer instead.
         return nativeCreateProof(
             rangeSize, numCustomFields, sysData, scId, lastWcert.orElse(null), utxoData.orElse(null), ftData.orElse(null),
-            provingKeyPath, false, zk, true, true
+            segmentSize, provingKeyPath, false, zk, true, true
         );
     }
 
     /**
+     * Compute proof for given parameters. Zero knowledge will be used.
+     * @param rangeSize - number of blocks between `mcbScTxsComStart` and `mcbScTxsComEnd`
+     * @param numCustomFields - exact number of custom fields the circuit must support
+     * @param sysData - certificate sys data.
+     * @param scId - the id of the corresponding sidechain
+     * @param lastWcert - the last confirmed wcert in the MC. Can be empty if SC has ceased before we have at least
+     *                    certs for 2 epochs (in this case we can only withdraw FT)
+     * @param utxoData - data required to prove withdraw of a SC utxo. Must be empty if the prover wants to prove
+     *                   withdraw of a FT instead. If this field is present, then lastWCert and sysData.scLastWCertHash
+     *                   must be present too.
+     * @param ftData - data required to prove withdraw of a FT. Must be empty if the prover wants to prove
+     *                 withdraw of a SC utxo instead. If present, then sysData.mcbScTxsComEnd must be present too.
+     * @param segmentSize - the segment size to be used to create the proof.
+     *                      Must be equal to the one passed to the setup() method.
+     *                      If not specified, it will default to the same size as the one passed to
+     *                      ProvingSystem.generateDLogKeys() method.
+     * @param provingKeyPath - file path from which reading the proving key, expected to be in compressed form
+     * @return the proof bytes
+     * @throws IllegalArgumentException if utxoData is present but lastWcert is empty, or if utxoData and ftData are both present
+     */
+    public static byte[] createProof(
+        int rangeSize,
+        int numCustomFields,
+        CswSysData sysData,
+        FieldElement scId,
+        Optional<WithdrawalCertificate> lastWcert,
+        Optional<CswUtxoProverData> utxoData,
+        Optional<CswFtProverData> ftData,
+        Optional<Integer> segmentSize,
+        String provingKeyPath
+    ) throws IllegalArgumentException 
+    {
+        checkCreateProofInputsConsistency(sysData, lastWcert, utxoData, ftData);
+
+        // Note: to avoid too much unpacking boilerplate Rust side, we pass the empty Optional instances as null pointer instead.
+        return nativeCreateProof(
+            rangeSize, numCustomFields, sysData, scId, lastWcert.orElse(null), utxoData.orElse(null), ftData.orElse(null),
+            segmentSize, provingKeyPath, false, true, true, true
+        );
+    }
+
+        /**
      * Compute proof for given parameters. Zero knowledge will be used.
      * @param rangeSize - number of blocks between `mcbScTxsComStart` and `mcbScTxsComEnd`
      * @param numCustomFields - exact number of custom fields the circuit must support
@@ -315,7 +417,7 @@ public class CswProof {
         // Note: to avoid too much unpacking boilerplate Rust side, we pass the empty Optional instances as null pointer instead.
         return nativeCreateProof(
             rangeSize, numCustomFields, sysData, scId, lastWcert.orElse(null), utxoData.orElse(null), ftData.orElse(null),
-            provingKeyPath, false, true, true, true
+            Optional.empty(), provingKeyPath, false, true, true, true
         );
     }
 

--- a/jni/src/main/java/com/horizen/provingsystemnative/ProvingSystem.java
+++ b/jni/src/main/java/com/horizen/provingsystemnative/ProvingSystem.java
@@ -10,28 +10,21 @@ public class ProvingSystem {
 
     private static native boolean nativeGenerateDLogKeys(
         ProvingSystemType psType,
-        int maxSegmentSize,
-        int supportedSegmentSize
+        int maxSegmentSize
     );
 
-    /*
-    * Generates DLOG keys of specified size and stores them in memory
-    * Returns True if operation was successfull, False otherwise.
-    * NOTE: SC is allowed to arbitrarly choose a segment size (via the parameter
-    *       `supportedSegmentSize`), regardless of the size of the MC ones;
-    *       However, we need to enforce SC keys being derived from MC keys,
-    *       and this internally requires to specify also the segment size chosen
-    *       by the MC (via the parameter maxSegmentSize).
-    *       Also, if supportedSegmentSize > maxSegmentSize, this function will
-    *       return False.
-    * */
+    /**
+     * Generates DLOG keys of specified size and stores them in memory
+     * @param psType - the proving system for which generating the keys
+     * @param segmentSize - the size of the keys
+     * @return True if operation was successfull, False otherwise.
+     */
     public static boolean generateDLogKeys(
         ProvingSystemType psType,
-        int maxSegmentSize,
-        int supportedSegmentSize
+        int segmentSize
     )
     {
-        return nativeGenerateDLogKeys(psType, maxSegmentSize, supportedSegmentSize);
+        return nativeGenerateDLogKeys(psType, segmentSize);
     }
 
     private static native boolean nativeCheckProofVkSize(

--- a/jni/src/test/java/com/horizen/TestUtils.java
+++ b/jni/src/test/java/com/horizen/TestUtils.java
@@ -3,6 +3,10 @@ package com.horizen;
 import com.google.common.io.BaseEncoding;
 
 public class TestUtils {
+    public static final int DLOG_KEYS_SIZE = 1 << 18;
+    public static final int CERT_SEGMENT_SIZE = 1 << 15;
+    public static final int CSW_SEGMENT_SIZE = 1 << 18;
+
     private TestUtils() {}
 
     public static byte[] fromHexString(String hex) {

--- a/jni/src/test/java/com/horizen/certnative/NaiveThresholdSigProofTest.java
+++ b/jni/src/test/java/com/horizen/certnative/NaiveThresholdSigProofTest.java
@@ -1,5 +1,6 @@
 package com.horizen.certnative;
 
+import com.horizen.TestUtils;
 import com.horizen.librustsidechains.FieldElement;
 import com.horizen.schnorrnative.SchnorrKeyPair;
 import com.horizen.schnorrnative.SchnorrPublicKey;
@@ -14,6 +15,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 import static org.junit.Assert.assertNotNull;
@@ -47,16 +49,14 @@ public class NaiveThresholdSigProofTest {
     static String snarkVkPathNoCustomFields = "./test_snark_vk";
     static String snarkPkPathCustomFields = "./test_snark_pk_with_custom_fields";
     static String snarkVkPathCustomFields = "./test_snark_vk_with_custom_fields";
-    static int maxSegmentSize = 1 << 17;
-    static int supportedSegmentSize = 1 << 15;
     static ProvingSystemType psType = ProvingSystemType.COBOUNDARY_MARLIN;
     
     @BeforeClass
     public static void initKeys() {
-        assertTrue(ProvingSystem.generateDLogKeys(psType, maxSegmentSize, supportedSegmentSize));
-        assertTrue(NaiveThresholdSigProof.setup(psType, keyCount, 0, snarkPkPathNoCustomFields, snarkVkPathNoCustomFields, zk, maxProofPlusVkSize));
-        assertTrue(NaiveThresholdSigProof.setup(psType, keyCount, customFieldsNum, snarkPkPathCustomFields, snarkVkPathCustomFields, zk, maxProofPlusVkSize));
-        assertFalse(NaiveThresholdSigProof.setup(psType, keyCount, 0, snarkPkPathNoCustomFields, snarkVkPathNoCustomFields, zk, 1));
+        ProvingSystem.generateDLogKeys(psType, TestUtils.DLOG_KEYS_SIZE);
+        assertTrue(NaiveThresholdSigProof.setup(psType, keyCount, 0, Optional.of(TestUtils.CERT_SEGMENT_SIZE), snarkPkPathNoCustomFields, snarkVkPathNoCustomFields, zk, maxProofPlusVkSize));
+        assertTrue(NaiveThresholdSigProof.setup(psType, keyCount, customFieldsNum, Optional.of(TestUtils.CERT_SEGMENT_SIZE), snarkPkPathCustomFields, snarkVkPathCustomFields, zk, maxProofPlusVkSize));
+        assertFalse(NaiveThresholdSigProof.setup(psType, keyCount, 0, Optional.of(TestUtils.CERT_SEGMENT_SIZE), snarkPkPathNoCustomFields, snarkVkPathNoCustomFields, zk, 1));
         assertEquals(
                 psType,
                 ProvingSystem.getVerifierKeyProvingSystemType(snarkVkPathNoCustomFields)
@@ -134,7 +134,7 @@ public class NaiveThresholdSigProofTest {
         CreateProofResult proofResult = NaiveThresholdSigProof.createProof(
             btList, scId, epochNumber, endCumulativeScTxCommTreeRoot,
             btrFee, ftMinAmount, signatureList, publicKeyList, threshold,
-            customFields, snarkPkPath, false, zk
+            customFields, Optional.of(TestUtils.CERT_SEGMENT_SIZE), snarkPkPath, false, zk
         );
 
         assertNotNull("Proof creation must be successful", proofResult);

--- a/jni/src/test/java/com/horizen/cswnative/CswProofTest.java
+++ b/jni/src/test/java/com/horizen/cswnative/CswProofTest.java
@@ -42,16 +42,14 @@ public class CswProofTest {
     
     static String snarkPkPath = "./test_csw_snark_pk";
     static String snarkVkPath = "./test_csw_snark_vk";
-    static int maxSegmentSize = 1 << 20;
-    static int supportedSegmentSize = 1 << 18;
     static ProvingSystemType psType = ProvingSystemType.COBOUNDARY_MARLIN;
     
     @BeforeClass
     public static void initKeys() {
         // Generate keys
-        assertTrue(ProvingSystem.generateDLogKeys(psType, maxSegmentSize, supportedSegmentSize));
-        assertTrue(CswProof.setup(psType, rangeSize, 2, false, snarkPkPath, snarkVkPath, zk, maxProofPlusVkSize));
-        assertFalse(CswProof.setup(psType, rangeSize, 2, false, snarkPkPath, snarkVkPath, zk, 1));
+        ProvingSystem.generateDLogKeys(psType, TestUtils.DLOG_KEYS_SIZE);
+        assertTrue(CswProof.setup(psType, rangeSize, 2, false, Optional.of(TestUtils.CSW_SEGMENT_SIZE), snarkPkPath, snarkVkPath, zk, maxProofPlusVkSize));
+        assertFalse(CswProof.setup(psType, rangeSize, 2, false, Optional.of(TestUtils.CSW_SEGMENT_SIZE), snarkPkPath, snarkVkPath, zk, 1));
         assertEquals(
             psType,
             ProvingSystem.getVerifierKeyProvingSystemType(snarkVkPath)
@@ -121,8 +119,8 @@ public class CswProofTest {
 
         // Create proof
         byte[] proof = CswProof.createProof(
-            rangeSize, 2, sysData, wCert.getScId(),
-            Optional.of(wCert), Optional.of(utxoData), Optional.empty(), snarkPkPath
+            rangeSize, 2, sysData, wCert.getScId(), Optional.of(wCert), Optional.of(utxoData),
+            Optional.empty(), Optional.of(TestUtils.CSW_SEGMENT_SIZE), snarkPkPath
         );
 
         // Proof verification must be successfull
@@ -228,8 +226,8 @@ public class CswProofTest {
 
         // Create proof
         byte[] proof = CswProof.createProof(
-            rangeSize, 2, sysData, wCert.getScId(), Optional.empty(),
-            Optional.empty(), Optional.of(ftData), snarkPkPath
+            rangeSize, 2, sysData, wCert.getScId(), Optional.empty(), Optional.empty(),
+            Optional.of(ftData), Optional.of(TestUtils.CSW_SEGMENT_SIZE), snarkPkPath
         );
         
         // Proof verification must be successfull


### PR DESCRIPTION
Keys can be generated just once.
However, it has been added the possibility to trim the keys to the desired segment size without the need to re-generating them.
For complete details look at the corresponding issue https://github.com/HorizenOfficial/zendoo-cctp-lib/issues/37 and PR https://github.com/HorizenOfficial/zendoo-cctp-lib/pull/38#issue-1089375960 on zendoo-cctp-lib