### PR TITLE
Fix Potential Underflows When Converting 64-bit Integers to Field Elements

### DIFF
--- a/api/src/cctp_calls.rs
+++ b/api/src/cctp_calls.rs
@@ -217,7 +217,7 @@ fn get_naive_threshold_sig_circuit_prover_data(
     }
 
     //Compute b as v-t and convert it to field element
-    let b = FieldElement::from(valid_signatures - threshold);
+    let b = FieldElement::from(valid_signatures) - FieldElement::from(threshold);
 
     //Convert affine pks to projective
     let pks = pks

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/next_cert.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/next_cert.rs
@@ -703,6 +703,7 @@ fn test_wrong_quality() {
     // decrease also by 1 the number of valid signatures
     circuit.wcert_signatures[0] = SchnorrSig::new(FieldElement::rand(&mut rng), FieldElement::rand(&mut rng));
     // Update b to ensure that b = valid_signatures - threshold
+    assert!(circuit.valid_signatures > 0); // check to avoid underflow, as the test would be meaningless with 0 valid signatures
     let b_bits = (FieldElement::from(circuit.valid_signatures as u64 - 1) - circuit.threshold).write_bits();
     let to_skip = FieldElement::size_in_bits() - circuit.b.len();
     circuit.b = b_bits[to_skip..].to_vec();

--- a/jni/src/main/java/com/horizen/librustsidechains/FieldElement.java
+++ b/jni/src/main/java/com/horizen/librustsidechains/FieldElement.java
@@ -19,6 +19,11 @@ public class FieldElement implements AutoCloseable {
 
     private static native FieldElement nativeCreateFromLong(long value);
 
+    /**
+     * Convert an integer value to a field element
+     * @param value - A positive integer value to be converted to a field element
+     * @return The field element represented with the positive integer value provided as input
+     */
     public static FieldElement createFromLong(long value) {
         return nativeCreateFromLong(value);
     }


### PR DESCRIPTION
Fix for the issue described in [PS 205](https://horizenlabs.atlassian.net/browse/PS-205):

When instantiating field elements from integer values, we need to take care of wrap-around in integer operations, as this might yield inconsistent behavior. For instance, `FieldElement::from(1)-FieldElement::from(2) != FieldElement::from(1-2)`, as -1 in the field is a different element than -1 in `u64` (i.e., `u64::MAX`). The same issue applies to the `FieldElement.createFromLong()` Java API, which relies on `FieldElement::from` under the hood.

This PR fixes the misuses of such conversion found in the library and adds documentation to `FieldElement.createFromLong()` Java method to specify that the function safely converts only positive integer values.