### PR TITLE
Document hash_to_curve function to specify it is not standard-compliant

### DIFF
--- a/demo-circuit/src/constants/mod.rs
+++ b/demo-circuit/src/constants/mod.rs
@@ -255,6 +255,10 @@ mod test {
         g
     }
 
+    // This method is safe to use only to generate fixed curve elements in a deterministic
+    // fashion. It should not be employed as a method to hash a sequence of bytes to a
+    // curve element, as it does not fulfill all the necessary statistical requirements of a
+    // standard-compliant hash function to curve elements
     fn hash_to_curve<F: PrimeField, G: AffineCurve + FromCompressedBits>(
         tag: &[u8],
         personalization: &[u8],


### PR DESCRIPTION
Add comment to `hash_to`curve` function to warn the caller that it is not a standard-compliant function to hash data to a curve element, and so the method should be used only to generate arbitrary curve elements in a deterministic way. This PR addresses the issue highlighted in the audit and tracked in [PS #214](https://horizenlabs.atlassian.net/jira/software/c/projects/PS/boards/38?modal=detail&selectedIssue=PS-214&assignee=62f0d6b525abc07e51c73b85)