### PR TITLE
Fix cargo audit to catch advisory where information is set to unsound and yanked crates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+ignore = [
+]
+informational_warnings = ["unmaintained", "unsound"]
+
+[output]
+deny = ["warnings", "unsound", "yanked"]
+quiet = false

--- a/ci/tests/002-cargo-audit.sh
+++ b/ci/tests/002-cargo-audit.sh
@@ -1,19 +1,16 @@
 #!/bin/bash
 
 set -uo pipefail
-
-echo "" && echo "=== Running cargo audit ===" && echo ""
-cargo audit --json > /tmp/audit.json
-jq '.' /tmp/audit.json
-
-VULNERABILITIES="$(jq '.vulnerabilities.found' /tmp/audit.json)"
+echo -e "Start cargo audit\n"
 
 if [ "$CARGO_AUDIT_EXIT_ON_ERROR" = "false" ]; then
-  echo -e "\nCargo audit disabled"
-elif [ "$VULNERABILITIES" = "true" ]; then
-  echo -e "\nVulnerabilities have been found"
-  jq '.vulnerabilities' /tmp/audit.json
+  echo -e "\nCargo audit error disabled"
+elif [ "$CARGO_AUDIT_EXIT_ON_ERROR" != "true" ]; then
+  echo -e "\nERROR: CARGO_AUDIT_EXIT_ON_ERROR should be only true|false and not '$CARGO_AUDIT_EXIT_ON_ERROR'"
   exit 1
-else
-  echo -e "\nNo vulnerabilities have been found"
 fi
+
+# Ok: if we want to ignore the `cargo audit` fail but we would see the report
+# we use $CARGO_AUDIT_EXIT_ON_ERROR set to false. In this case we ignore the
+# `cargo audit` output value and we return always `true`.
+cargo audit || ! eval "$CARGO_AUDIT_EXIT_ON_ERROR"


### PR DESCRIPTION
Fix cargo audit to catch advisory where information is set to unsound and yunked crates

We added audit.toml to configure cargo audit to catch this kind of warning and expose them as errors. We ignored a atty unsound error because we use atty just for banches and test logging.

More we removed the hack in the check script that relayed on json output and not on cargo audit script output values.

closes(partially): PS-231 https://horizenlabs.atlassian.net/browse/PS-231