### PR TITLE
PS-217: Implement the circuit for SC2SC verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.7.0"
+version = "0.8.0-SNAPSHOT"
 dependencies = [
  "algebra",
  "blake2",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "demo-circuit"
-version = "0.7.0"
+version = "0.8.0-SNAPSHOT"
 dependencies = [
  "algebra",
  "bit-vec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -308,6 +308,7 @@ dependencies = [
  "r1cs-std",
  "radix_trie",
  "rand",
+ "rstest",
  "serial_test",
  "sha2",
  "strum",
@@ -322,7 +323,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -358,7 +359,7 @@ version = "0.6.0"
 source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -371,6 +372,101 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -609,6 +705,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,11 +766,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -688,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -833,6 +941,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +1019,7 @@ checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -907,7 +1041,7 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -926,6 +1060,15 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -950,7 +1093,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -961,13 +1104,24 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -987,7 +1141,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -997,10 +1151,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
+name = "unicode-ident"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unroll"
@@ -1009,7 +1163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.7.0"
+version = "0.8.0-SNAPSHOT"
 authors = [
     "DanieleDiBenedetto <daniele@horizenlabs.io>",
     "Oleksandr Iozhytsia <oleksandr@zensystem.io>",

--- a/api/src/jni_wrapper.rs
+++ b/api/src/jni_wrapper.rs
@@ -1,0 +1,85 @@
+use jni::{JNIEnv, objects::{JObject, JValue}, sys::jlong, errors::Error};
+
+use crate::utils::{read_raw_pointer, read_mut_raw_pointer};
+
+/// Define how to map the entity into a native Rust reference. It is implemented just for
+/// everything that can be converted into a `JObject`.
+pub(crate) trait AsNativeRef<'j, 'e:'j, T: JNINativeWrapper>: Sized + Into<JObject<'j>>{
+    /// Return a reference to a Rust object that is wrapped on Java (maybe with a raw pointer)
+    fn as_native_ref(self, env: JNIEnv<'e>) -> Result<&'j T, jni::errors::Error> {
+        env.get_field(self, T::INNER_FIELD, "J")
+            .and_then(|field| field.j())
+            .map(|fe| read_raw_pointer(&env, fe as *const T))
+    }
+
+    /// Return a reference to a Rust object that is wrapped on Java (maybe with a raw pointer).
+    /// It will panic if something go wrong.
+    fn as_native_ref_unchecked(self, env: JNIEnv<'e>) -> &'j T {
+        Self::as_native_ref(self, env)
+            .expect(&format!("Should be able to get field {}", T::INNER_FIELD))
+    }
+}
+
+/// Define how to map the entity into a native mutable Rust reference. It is implemented just for
+/// everything that can be converted into a `JObject`.
+pub(crate) trait AsNativeRefMut<'j, 'e:'j, T: JNINativeWrapper>: AsNativeRef<'j, 'e, T> {
+    /// Return a mutable reference to a Rust object that is wrapped on Java (maybe with a 
+    /// raw pointer)
+    fn as_native_mut_ref(self, env: JNIEnv<'e>) -> Result<&'j mut T, jni::errors::Error>{
+        env.get_field(self, T::INNER_FIELD, "J")
+            .and_then(|field| field.j())
+            .map(|fe| read_mut_raw_pointer(&env, fe as *mut T))
+    }
+
+    /// Return a mutable reference to a Rust object that is wrapped on Java (maybe with a raw pointer).
+    /// It will panic if something go wrong.
+    fn as_native_ref_mut_unchecked(self, env: JNIEnv<'e>) -> &'j mut T {
+        Self::as_native_mut_ref(self, env)
+            .expect(&format!("Should be able to get field {}", T::INNER_FIELD))
+    }
+}
+
+impl<'j, 'e: 'j, T: JNINativeWrapper, J: Into<JObject<'j>>> AsNativeRef<'j, 'e, T> for J {}
+impl<'j, 'e: 'j, T: JNINativeWrapper, J: Into<JObject<'j>>> AsNativeRefMut<'j, 'e, T> for J {}
+
+/// Define a simple java wrapper that hold the rust raw pointer in 
+/// a `long` java value stored in the `INNER_FIELD` field. You should
+/// define the package in `JAVA_PACKAGE` and the java class name
+/// in `INNER_FIELD`.
+pub(crate) trait JNINativeWrapper: Sized {
+    /// The complete java package of the Wrapper class
+    const JAVA_PACKAGE: &'static str;
+    /// The java class name
+    const JAVA_CLASS: &'static str;
+    /// The inner field name
+    const INNER_FIELD: &'static str;
+
+    /// Return the Java object that wrap the Rust one
+    fn wrap(self, env: JNIEnv) -> Result<JObject, Error> {
+        let ptr: jlong = Box::into_raw(Box::new(self)) as i64;
+        env
+            .find_class(Self::path())
+            .and_then(|cls| 
+                env.new_object(cls, "(J)V", &[JValue::Long(ptr)])
+            )
+    }
+
+    /// Return the Java object that wrap the Rust one. It will panic if something goes wrong.
+    fn wrap_unchecked(self, env: JNIEnv) -> JObject {
+        self.wrap(env)
+            .expect(&format!("Should be able to create {} object", Self::JAVA_CLASS))
+    }
+
+    /// Dealloc the raw pointer
+    fn free(ptr: *mut Self) {
+        if ptr.is_null() {
+            return;
+        }
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+
+    /// The full path of the class
+    fn path() -> String {
+        format!("{}/{}", Self::JAVA_PACKAGE, Self::JAVA_CLASS)
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -50,7 +50,7 @@ use demo_circuit::{
     type_mapping::*,
 };
 
-use jni_wrapper::{AsNativeRefMut, AsNativeRef, JNINativeWrapper};
+use jni_wrapper::{AsNativeRef, AsNativeRefMut, JNINativeWrapper};
 use primitives::{
     bytes_to_bits, signature::schnorr::field_based_schnorr::FieldBasedSchnorrPk, FieldBasedHash,
     FieldBasedMerkleTree, FieldBasedMerkleTreePath, FieldBasedSparseMerkleTree, FieldHasher,
@@ -5939,8 +5939,7 @@ ffi_export!(
         ) {
             Ok(proof) => {
                 //Return proof serialized
-                env
-                    .byte_array_from_slice(proof.as_slice())
+                env.byte_array_from_slice(proof.as_slice())
                     .expect("Should be able to convert Rust slice into jbytearray")
             }
             Err(e) => {
@@ -5966,7 +5965,6 @@ ffi_export!(
         check_vk: jboolean,
         compressed_vk: jboolean,
     ) -> jboolean {
-
         let next_sc_tx_commitments_root: &FieldElement =
             next_sc_tx_commitments_root.as_native_ref_unchecked(env);
         let curr_sc_tx_commitments_root: &FieldElement =
@@ -6070,6 +6068,32 @@ ffi_export!(
             JNI_TRUE
         } else {
             JNI_FALSE
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeUpdateScCommitmentPath(
+        env: JNIEnv,
+        path: JObject,
+        sc_commitment_path: JObject,
+    ) -> jboolean {
+        let path: &mut ScCommitmentCertPath = path.as_native_ref_mut_unchecked(env);
+        let sc_commitment_path: &GingerMHTPath =
+            sc_commitment_path.as_native_ref_unchecked(env);
+
+        match sc_commitment_path
+            .clone()
+            .try_into()
+            .and_then(|p| path.update_sc_commitment_path(p).into())
+        {
+            Ok(_) => JNI_TRUE,
+            Err(e) => throw!(
+                &env,
+                "java/lang/IllegalArgumentException",
+                format!("Cannot update path: {:?}", e).as_str(),
+                JNI_FALSE
+            ),
         }
     }
 );

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -24,33 +24,37 @@ use cctp_primitives::{
         CommitmentTree, CMT_MT_HEIGHT,
     },
     proving_system::{compute_proof_vk_size, init_dlog_keys, ProvingSystem, ZendooVerifierKey},
-    utils::{
-        commitment_tree::hash_vec, data_structures::*,
-        get_cert_data_hash_from_bt_root_and_custom_fields_hash, mht::*, poseidon_hash::*,
-        serialization::*,
-    },
+    utils::{data_structures::*, mht::*, poseidon_hash::*, serialization::*},
 };
 use demo_circuit::{
-    naive_threshold_sig::NaiveThresholdSignature,
-    naive_threshold_sig_w_key_rotation::{
-        NaiveThresholdSignatureWKeyRotation,
-        data_structures::ValidatorKeysUpdates,
-    },
     blaze_csw::{
         constraints::CeasedSidechainWithdrawalCircuit,
         data_structures::{
             CswFtOutputData, CswFtProverData, CswSysData, CswUtxoInputData, CswUtxoOutputData,
-            CswUtxoProverData
-        }, deserialize_fe_unchecked,
+            CswUtxoProverData,
+        },
+        deserialize_fe_unchecked,
     },
-    common::{data_structures::WithdrawalCertificateData, NULL_CONST},
+    common::{
+        data_structures::WithdrawalCertificateData, MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS,
+        MIN_CUSTOM_FIELDS, MSG_ROOT_HASH_CUSTOM_FIELDS_POS, NULL_CONST,
+    },
     constants::{personalizations::BoxType, *},
     generate_circuit_keypair,
+    naive_threshold_sig::NaiveThresholdSignature,
+    naive_threshold_sig_w_key_rotation::{
+        data_structures::ValidatorKeysUpdates, NaiveThresholdSignatureWKeyRotation,
+    },
     read_field_element_from_buffer_with_padding,
+    sc2sc::{Sc2Sc, ScCommitmentCertPath, MSG_MT_HEIGHT},
     type_mapping::*,
 };
 
-use primitives::{bytes_to_bits, signature::schnorr::field_based_schnorr::FieldBasedSchnorrPk, FieldBasedHash, FieldBasedMerkleTree, FieldBasedMerkleTreePath, FieldBasedSparseMerkleTree, FieldHasher};
+use jni_wrapper::{AsNativeRefMut, AsNativeRef, JNINativeWrapper};
+use primitives::{
+    bytes_to_bits, signature::schnorr::field_based_schnorr::FieldBasedSchnorrPk, FieldBasedHash,
+    FieldBasedMerkleTree, FieldBasedMerkleTreePath, FieldBasedSparseMerkleTree, FieldHasher,
+};
 use std::{
     any::type_name,
     collections::{HashMap, HashSet},
@@ -77,6 +81,44 @@ use jni::{sys::jlongArray, JNIEnv};
 use std::convert::TryInto;
 
 //Field element related functions
+
+mod jni_wrapper;
+
+//TODO: We should use JNINativeWrapper and JNIMutNativeWrapper traits for every struct
+// that is wrapped by a raw pointer in Java and replace all old approaches.
+// See Java_com_horizen_sc2scnative_Sc2Sc_nativeCreateProof as example.
+
+impl JNINativeWrapper for FieldElement {
+    const INNER_FIELD: &'static str = "fieldElementPointer";
+
+    const JAVA_PACKAGE: &'static str = "com/horizen/librustsidechains";
+
+    const JAVA_CLASS: &'static str = "FieldElement";
+}
+
+impl JNINativeWrapper for ScCommitmentCertPath {
+    const INNER_FIELD: &'static str = "scCommitmentCertPathPointer";
+
+    const JAVA_PACKAGE: &'static str = "com/horizen/commitmenttreenative";
+
+    const JAVA_CLASS: &'static str = "ScCommitmentCertPath";
+}
+
+impl JNINativeWrapper for CommitmentTree {
+    const INNER_FIELD: &'static str = "commitmentTreePointer";
+
+    const JAVA_PACKAGE: &'static str = "com/horizen/commitmenttreenative";
+
+    const JAVA_CLASS: &'static str = "CommitmentTree";
+}
+
+impl JNINativeWrapper for GingerMHTPath {
+    const INNER_FIELD: &'static str = "merklePathPointer";
+
+    const JAVA_PACKAGE: &'static str = "com/horizen/merkletreenative";
+
+    const JAVA_CLASS: &'static str = "MerklePath";
+}
 
 ffi_export!(
     fn Java_com_horizen_librustsidechains_Library_nativePanickingFunction(
@@ -124,6 +166,16 @@ ffi_export!(
         set_constant!("VRF_PK_LENGTH", VRF_PK_SIZE);
         set_constant!("VRF_SK_LENGTH", VRF_SK_SIZE);
         set_constant!("VRF_PROOF_LENGTH", VRF_PROOF_SIZE);
+        set_constant!(
+            "MSG_ROOT_HASH_CUSTOM_FIELDS_POS",
+            MSG_ROOT_HASH_CUSTOM_FIELDS_POS
+        );
+        set_constant!(
+            "MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS",
+            MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS
+        );
+        set_constant!("MIN_CUSTOM_FIELDS", MIN_CUSTOM_FIELDS);
+        set_constant!("MSG_MT_HEIGHT", MSG_MT_HEIGHT);
     }
 );
 
@@ -5232,24 +5284,8 @@ ffi_export!(
         // Parse cert
         let cert = parse_wcert(_env, _cert);
 
-        // Convert custom fields in the expected form
-        let custom_fields_hash = if cert.custom_fields.is_empty() {
-            None
-        } else {
-            Some(hash_vec(cert.custom_fields).unwrap())
-        };
-
         // Compute hash
-        match get_cert_data_hash_from_bt_root_and_custom_fields_hash(
-            &cert.ledger_id,
-            cert.epoch_id,
-            cert.quality,
-            cert.bt_root,
-            custom_fields_hash,
-            &cert.mcb_sc_txs_com,
-            cert.btr_min_fee,
-            cert.ft_min_amount,
-        ) {
+        match cert.hash() {
             Ok(digest) => return_field_element(&_env, digest),
             Err(e) => {
                 log!(format!("Error while computing cert hash: {:?}", e));
@@ -5754,6 +5790,382 @@ ffi_export!(
                 log!(format!("Unable to verify CSW proof: {:?}", e));
                 JNI_FALSE
             } // CRYPTO_ERROR or IO_ERROR
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeFreeScCommitmentCertPath(
+        env: JNIEnv,
+        _class: JClass,
+        path: *mut ScCommitmentCertPath,
+    ) {
+        ScCommitmentCertPath::free(path)
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_sc2scnative_Sc2Sc_nativeSetup(
+        env: JNIEnv,
+        _class: JClass,
+        proving_system: JObject,
+        num_custom_fields: jint,
+        segment_size: JObject,
+        proving_key_path: JString,
+        verification_key_path: JString,
+        zk: jboolean,
+        max_proof_plus_vk_size: jint,
+        compress_pk: jboolean,
+        compress_vk: jboolean,
+    ) -> jboolean {
+        // Get proving system type
+        let proving_system = get_proving_system_type(&env, proving_system);
+
+        // Get supported degree
+        let supported_degree =
+            cast_joption_to_rust_option(&env, segment_size).map(|integer_object| {
+                env.call_method(integer_object, "intValue", "()I", &[])
+                    .expect("Should be able to call intValue() on Optional<Integer>")
+                    .i()
+                    .unwrap() as usize
+                    - 1
+            });
+
+        // Read paths
+        let proving_key_path = env
+            .get_string(proving_key_path)
+            .expect("Should be able to read jstring as Rust String");
+
+        let verification_key_path = env
+            .get_string(verification_key_path)
+            .expect("Should be able to read jstring as Rust String");
+
+        let circ = Sc2Sc::get_instance_for_setup(num_custom_fields as u32);
+
+        // Read zk value
+        let zk = zk == JNI_TRUE;
+
+        // Generate snark keypair
+        match generate_circuit_keypair(
+            circ,
+            proving_system,
+            supported_degree,
+            Path::new(proving_key_path.to_str().unwrap()),
+            Path::new(verification_key_path.to_str().unwrap()),
+            max_proof_plus_vk_size as usize,
+            zk,
+            Some(compress_pk == JNI_TRUE),
+            Some(compress_vk == JNI_TRUE),
+        ) {
+            Ok(_) => JNI_TRUE,
+            Err(e) => {
+                throw!(
+                    &env,
+                    "java/lang/Exception",
+                    format!("(Pk, Vk) generation failed: {:?}", e).as_str(),
+                    JNI_FALSE
+                );
+            }
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_sc2scnative_Sc2Sc_nativeCreateProof(
+        env: JNIEnv,
+        _class: JClass,
+        next_sc_tx_commitments_root: JObject,
+        curr_sc_tx_commitments_root: JObject,
+        msg_hash: JObject,
+        next_withdrawal_certificate: JObject,
+        curr_withdrawal_certificate: JObject,
+        next_cert_commitment_path: JObject,
+        curr_cert_commitment_path: JObject,
+        msg_path: JObject,
+
+        segment_size: JObject,
+        proving_key_path: JString,
+        check_proving_key: jboolean,
+        zk: jboolean,
+        compressed_pk: jboolean,
+        compress_proof: jboolean,
+    ) -> jobject {
+        let next_sc_tx_commitments_root: &FieldElement =
+            next_sc_tx_commitments_root.as_native_ref_unchecked(env);
+        let curr_sc_tx_commitments_root: &FieldElement =
+            curr_sc_tx_commitments_root.as_native_ref_unchecked(env);
+        let msg_hash: &FieldElement = msg_hash.as_native_ref_unchecked(env);
+        let next_withdrawal_certificate = parse_wcert(env, next_withdrawal_certificate);
+        let curr_withdrawal_certificate = parse_wcert(env, curr_withdrawal_certificate);
+        let next_cert_commitment_path: &ScCommitmentCertPath =
+            next_cert_commitment_path.as_native_ref_unchecked(env);
+        let curr_cert_commitment_path: &ScCommitmentCertPath =
+            curr_cert_commitment_path.as_native_ref_unchecked(env);
+        let msg_path: &GingerMHTPath = msg_path.as_native_ref_unchecked(env);
+        // Get supported degree
+        let supported_degree =
+            cast_joption_to_rust_option(&env, segment_size).map(|integer_object| {
+                env.call_method(integer_object, "intValue", "()I", &[])
+                    .expect("Should be able to call intValue() on Optional<Integer>")
+                    .i()
+                    .unwrap() as usize
+                    - 1
+            });
+
+        //Extract params_path str
+        let proving_key_path = env
+            .get_string(proving_key_path)
+            .expect("Should be able to read jstring as Rust String");
+        let check_proving_key = check_proving_key == JNI_TRUE;
+        let zk = zk == JNI_TRUE;
+        let compressed_pk = compressed_pk == JNI_TRUE;
+        let compress_proof = compress_proof == JNI_TRUE;
+
+        match create_native_sc2sc_proof(
+            next_sc_tx_commitments_root.clone(),
+            curr_sc_tx_commitments_root.clone(),
+            msg_hash.clone(),
+            next_withdrawal_certificate,
+            curr_withdrawal_certificate,
+            next_cert_commitment_path.clone(),
+            curr_cert_commitment_path.clone(),
+            msg_path.clone(),
+            supported_degree,
+            Path::new(proving_key_path.to_str().unwrap()),
+            check_proving_key,
+            zk,
+            compressed_pk,
+            compress_proof,
+        ) {
+            Ok(proof) => {
+                //Return proof serialized
+                env
+                    .byte_array_from_slice(proof.as_slice())
+                    .expect("Should be able to convert Rust slice into jbytearray")
+            }
+            Err(e) => {
+                log!(format!("Error creating Sc2Sc proof {:?}", e));
+                JObject::null().into_inner()
+            }
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_sc2scnative_Sc2Sc_nativeVerifyProof(
+        env: JNIEnv,
+        _class: JClass,
+        next_sc_tx_commitments_root: JObject,
+        curr_sc_tx_commitments_root: JObject,
+        msg_hash: JObject,
+
+        proof_bytes: jbyteArray,
+        vk_path: JString,
+        check_proof: jboolean,
+        compressed_proof: jboolean,
+        check_vk: jboolean,
+        compressed_vk: jboolean,
+    ) -> jboolean {
+
+        let next_sc_tx_commitments_root: &FieldElement =
+            next_sc_tx_commitments_root.as_native_ref_unchecked(env);
+        let curr_sc_tx_commitments_root: &FieldElement =
+            curr_sc_tx_commitments_root.as_native_ref_unchecked(env);
+        let msg_hash: &FieldElement = msg_hash.as_native_ref_unchecked(env);
+
+        let proof_bytes = env
+            .convert_byte_array(proof_bytes)
+            .expect("Should be able to convert to Rust byte array");
+
+        let vk_path = env
+            .get_string(vk_path)
+            .expect("Should be able to read jstring as Rust String");
+        let check_proof = check_proof == JNI_TRUE;
+        let compressed_proof = compressed_proof == JNI_TRUE;
+        let check_vk = check_vk == JNI_TRUE;
+        let compressed_vk = compressed_vk == JNI_TRUE;
+
+        //Verify proof
+        match verify_sc2sc_proof(
+            next_sc_tx_commitments_root.clone(),
+            curr_sc_tx_commitments_root.clone(),
+            msg_hash.clone(),
+            proof_bytes,
+            check_proof,
+            compressed_proof,
+            Path::new(vk_path.to_str().unwrap()),
+            check_vk,
+            compressed_vk,
+        ) {
+            Ok(result) => {
+                if result {
+                    JNI_TRUE
+                } else {
+                    JNI_FALSE
+                }
+            }
+            Err(e) => {
+                log!(format!("Unable to verify Sc2Sc proof: {:?}", e));
+                JNI_FALSE
+            }
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeApply(
+        env: JNIEnv,
+        path: JObject,
+        sc_id: JObject,
+        hash: JObject,
+    ) -> jobject {
+        let sc_id = sc_id.as_native_ref_unchecked(env);
+        let hash = hash.as_native_ref_unchecked(env);
+        let path: &ScCommitmentCertPath = path.as_native_ref_unchecked(env);
+
+        let empty = optional_empty(env);
+
+        if !path.is_valid() {
+            return empty;
+        }
+
+        match path.compute_root(sc_id, hash) {
+            Ok(root) => {
+                let inner =
+                    return_jobject(&env, root, "com/horizen/librustsidechains/FieldElement");
+                let cls_optional = env.find_class("java/util/Optional").unwrap();
+                let res = env
+                    .call_static_method(
+                        cls_optional,
+                        "of",
+                        "(Ljava/lang/Object;)Ljava/util/Optional;",
+                        &[JValue::Object(inner)],
+                    )
+                    .unwrap();
+                *res.l().unwrap()
+            }
+            Err(_) => empty,
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeVerify(
+        env: JNIEnv,
+        path: JObject,
+        root: JObject,
+        sc_id: JObject,
+        hash: JObject,
+    ) -> jboolean {
+        let root = root.as_native_ref_unchecked(env);
+        let sc_id = sc_id.as_native_ref_unchecked(env);
+        let hash = hash.as_native_ref_unchecked(env);
+        let path: &ScCommitmentCertPath = path.as_native_ref_unchecked(env);
+
+        if !path.is_valid() {
+            return JNI_FALSE;
+        }
+
+        if path.check_membership(root, sc_id, hash) {
+            JNI_TRUE
+        } else {
+            JNI_FALSE
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeSerialize(
+        env: JNIEnv,
+        path: JObject,
+    ) -> jbyteArray {
+        serialize_from_jobject::<ScCommitmentCertPath>(
+            &env,
+            path,
+            <ScCommitmentCertPath as JNINativeWrapper>::INNER_FIELD,
+            None,
+        )
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeDeserialize(
+        env: JNIEnv,
+        _class: JClass,
+        path_bytes: jbyteArray,
+        checked: jboolean,
+    ) -> jobject {
+        deserialize_to_jobject::<ScCommitmentCertPath>(
+            &env,
+            path_bytes,
+            Some(checked),
+            None,
+            "com/horizen/commitmenttreenative/ScCommitmentCertPath",
+        )
+    }
+);
+
+fn optional_empty(env: JNIEnv) -> jobject {
+    let cls_optional = env.find_class("java/util/Optional").unwrap();
+
+    let empty_res = env
+        .call_static_method(cls_optional, "empty", "()Ljava/util/Optional;", &[])
+        .expect("Should be able to create new value for Optional.empty()");
+    *empty_res.l().unwrap()
+}
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_CommitmentTree_nativeGetScCommitmentCertPath(
+        env: JNIEnv,
+        commitment_tree: JObject,
+        sc_id: jbyteArray,
+        cert_hash: jbyteArray,
+    ) -> jobject {
+        let sc_id = FieldElement::deserialize(
+            parse_jbyte_array_to_vec(&env, &sc_id, FIELD_SIZE).as_slice(),
+        )
+        .expect("Can't parse the input sc_id_bytes into FieldElement");
+        let cert_hash = FieldElement::deserialize(
+            parse_jbyte_array_to_vec(&env, &cert_hash, FIELD_SIZE).as_slice(),
+        )
+        .expect("Can't parse the input cert_hash_bytes into FieldElement");
+
+        let commitment_tree: &mut CommitmentTree = commitment_tree.as_native_ref_mut_unchecked(env);
+
+        let empty = optional_empty(env);
+
+        let cert_leaf_index = match commitment_tree
+            .get_cert_leaves(&sc_id)
+            .and_then(|certs| certs.iter().position(|h| h == &cert_hash))
+        {
+            Some(index) => index,
+            None => return empty,
+        };
+
+        let cls_optional = env.find_class("java/util/Optional").unwrap();
+
+        match ScCommitmentCertPath::from_commitment_cert_index(
+            commitment_tree,
+            sc_id,
+            cert_leaf_index,
+        ) {
+            Ok(path) => {
+                let jep = path.wrap_unchecked(env);
+
+                let res = env
+                    .call_static_method(
+                        cls_optional,
+                        "of",
+                        "(Ljava/lang/Object;)Ljava/util/Optional;",
+                        &[JValue::Object(jep)],
+                    )
+                    .unwrap();
+                *res.l().unwrap()
+            }
+            Err(_) => {
+                // Ignore it and return a generic None
+                empty
+            }
         }
     }
 );

--- a/demo-circuit/Cargo.toml
+++ b/demo-circuit/Cargo.toml
@@ -53,6 +53,7 @@ hex = "0.4.3"
 serial_test = "0.5.1"
 strum = "0.24.1"
 strum_macros = "0.24.3"
+rstest = { version = "0.17.0", no-default-features = true }
 
 [features]
 default = ["asm"]

--- a/demo-circuit/Cargo.toml
+++ b/demo-circuit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demo-circuit"
-version = "0.7.0"
+version = "0.8.0-SNAPSHOT"
 authors = [
     "DanieleDiBenedetto <daniele@horizenlabs.io>",
     "Oleksandr Iozhytsia <oleksandr@zensystem.io>",

--- a/demo-circuit/src/blaze_csw/constraints/mod.rs
+++ b/demo-circuit/src/blaze_csw/constraints/mod.rs
@@ -190,7 +190,7 @@ impl ConstraintSynthesizer<FieldElement> for CeasedSidechainWithdrawalCircuit {
             )
         };
 
-        // Enforce UTXO widthdrawal if required
+        // Enforce UTXO withdrawal if required
         csw_data_g
             .utxo_data_g
             .conditionally_enforce_utxo_withdrawal(

--- a/demo-circuit/src/common/data_structures.rs
+++ b/demo-circuit/src/common/data_structures.rs
@@ -1,7 +1,10 @@
 use crate::constants::NaiveThresholdSigParams;
 use cctp_primitives::{
-    type_mapping::FieldElement,
-    utils::{data_structures::BackwardTransfer, get_bt_merkle_root},
+    type_mapping::{Error, FieldElement},
+    utils::{
+        commitment_tree::hash_vec, data_structures::BackwardTransfer, get_bt_merkle_root,
+        get_cert_data_hash_from_bt_root_and_custom_fields_hash,
+    },
 };
 
 use lazy_static::*;
@@ -23,8 +26,6 @@ pub struct WithdrawalCertificateData {
     pub mcb_sc_txs_com: FieldElement,
     pub ft_min_amount: u64,
     pub btr_min_fee: u64,
-    /// Carries the reference to the sidechain state. (Currently the reference is
-    /// split over two field elements)
     pub custom_fields: Vec<FieldElement>,
 }
 
@@ -55,6 +56,24 @@ impl WithdrawalCertificateData {
             btr_min_fee,
             custom_fields,
         }
+    }
+
+    pub fn hash(&self) -> Result<FieldElement, Error> {
+        let custom_fields_hash = if self.custom_fields.len() > 0 {
+            Some(hash_vec(self.custom_fields.clone())?)
+        } else {
+            None
+        };
+        get_cert_data_hash_from_bt_root_and_custom_fields_hash(
+            &self.ledger_id,
+            self.epoch_id,
+            self.quality,
+            self.bt_root,
+            custom_fields_hash,
+            &self.mcb_sc_txs_com,
+            self.btr_min_fee,
+            self.ft_min_amount,
+        )
     }
 
     pub(crate) fn get_default(num_custom_fields: u32) -> Self {

--- a/demo-circuit/src/common/data_structures.rs
+++ b/demo-circuit/src/common/data_structures.rs
@@ -9,6 +9,13 @@ use cctp_primitives::{
 
 use lazy_static::*;
 
+/// Minumum number of custom fields
+pub const MIN_CUSTOM_FIELDS: usize = 3;
+/// The position of Message Root Hash in the custom fields: See ZenIP-42205
+pub const MSG_ROOT_HASH_CUSTOM_FIELDS_POS: usize = 1;
+/// The position of Max Quality Cert Hash in the custom fields: See ZenIP-42205
+pub const MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS: usize = 2;
+
 lazy_static! {
     pub static ref NULL_CONST: NaiveThresholdSigParams = NaiveThresholdSigParams::new();
 }

--- a/demo-circuit/src/lib.rs
+++ b/demo-circuit/src/lib.rs
@@ -49,7 +49,10 @@ pub mod blaze_csw;
 pub mod common;
 pub mod naive_threshold_sig;
 pub mod naive_threshold_sig_w_key_rotation;
+pub mod sc2sc;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub mod utils;
 
 pub mod constants;

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/first_cert.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/first_cert.rs
@@ -1,3 +1,5 @@
+use crate::test_utils::init_g1_committer_key;
+
 use super::utils::*;
 use super::*;
 use cctp_primitives::proving_system::verifier::ceased_sidechain_withdrawal::PHANTOM_CERT_DATA_HASH;

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/mod.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/mod.rs
@@ -3,10 +3,7 @@ mod next_cert;
 mod utils;
 mod verify;
 
-use cctp_primitives::{
-    proving_system::init::{get_g1_committer_key, load_g1_committer_key},
-    utils::commitment_tree::hash_vec,
-};
+use cctp_primitives::utils::commitment_tree::hash_vec;
 use primitives::schnorr::field_based_schnorr::FieldBasedSchnorrPk;
 use primitives::{
     schnorr::field_based_schnorr::FieldBasedSchnorrSignature, FieldBasedHash,
@@ -23,8 +20,6 @@ use crate::{
     type_mapping::*,
 };
 use rand::Rng;
-
-use crate::{MAX_SEGMENT_SIZE, SUPPORTED_SEGMENT_SIZE};
 
 use super::{data_structures::ValidatorKeysUpdates, NaiveThresholdSignatureWKeyRotation};
 

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/next_cert.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/next_cert.rs
@@ -1,5 +1,7 @@
 use algebra::{Field, PrimeField, ToBits, UniformRand};
 use cctp_primitives::proving_system::verifier::ceased_sidechain_withdrawal::PHANTOM_CERT_DATA_HASH;
+use crate::test_utils::init_g1_committer_key;
+
 use super::utils::*;
 use super::*;
 

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/utils.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/utils.rs
@@ -50,13 +50,6 @@ pub(crate) fn create_signatures(
     signatures
 }
 
-pub(crate) fn init_g1_committer_key() -> CommitterKeyG1 {
-    let _ = load_g1_committer_key(MAX_SEGMENT_SIZE - 1);
-    let ck_g1 = get_g1_committer_key(Some(SUPPORTED_SEGMENT_SIZE - 1)).unwrap();
-    assert_eq!(ck_g1.comm_key.len(), SUPPORTED_SEGMENT_SIZE);
-    ck_g1
-}
-
 pub(crate) fn get_cert_data_hash(
     withdrawal_certificate: &WithdrawalCertificateData,
 ) -> FieldElement {

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/verify.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/tests/verify.rs
@@ -1,3 +1,5 @@
+use crate::test_utils::init_g1_committer_key;
+
 use super::super::*;
 use super::*;
 

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -1,0 +1,316 @@
+use algebra::Field;
+use cctp_primitives::{
+    commitment_tree::{sidechain_tree_alive::CERT_MT_HEIGHT, CMT_MT_HEIGHT},
+    type_mapping::FieldElement,
+};
+use primitives::FieldBasedMerkleTreePath;
+use r1cs_core::ConstraintSynthesizer;
+use r1cs_crypto::{FieldBasedHashGadget, FieldBasedMerkleTreePathGadget, FieldHasherGadget};
+use r1cs_std::{
+    fields::fp::FpGadget,
+    prelude::{AllocGadget, EqGadget, FieldGadget},
+    FromBitsGadget,
+};
+
+use crate::{
+    common::{constraints::WithdrawalCertificateDataGadget, WithdrawalCertificateData},
+    FieldElementGadget, FieldHashGadget, GingerMHTBinaryGadget, GingerMHTBinaryPath,
+};
+
+/// The height of the Messages Merkle Tree in the current epoch
+pub const MSG_MT_HEIGHT: usize = 12;
+pub const MIN_CUSTOM_FIELDS: usize = 3;
+pub const MSG_ROOT_HASH_CUSTOM_FIELDS_POS: usize = 1;
+pub const MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS: usize = 2;
+
+#[derive(Clone)]
+pub struct Sc2Sc {
+    // Public Inputs
+    /// Side Chain Tx Commitment  Root of epoch N+1
+    next_sc_tx_commitments_root: FieldElement,
+    /// Side Chain Tx Commitment  Root of epoch N
+    curr_sc_tx_commitments_root: FieldElement,
+    /// Hash of the message to be redeemed
+    msg_hash: FieldElement,
+
+    // Witnesses
+    /// Certificate of epoch N+1
+    next_cert: WithdrawalCertificateData,
+    /// Certificate of epoch N
+    curr_cert: WithdrawalCertificateData,
+    /// Path of `next_cert` in the next sc_tx_commitment tree
+    next_cert_path: ScCommitmentCertPath,
+    /// Path of `curr_cert` in the current sc_tx_commitment tree
+    curr_cert_path: ScCommitmentCertPath,
+    /// Merkle path of the message to be redeemed inside
+    /// SC2SC_message_tree_root that you can fine in `curr_cert`.
+    /// This value is in the custom fields position 1.
+    msg_path: GingerMHTBinaryPath,
+}
+
+impl Sc2Sc {
+    /// Create a new circuit data to build the circuit
+    pub fn new(
+        next_sc_tx_commitments_root: FieldElement,
+        curr_sc_tx_commitments_root: FieldElement,
+        msg_hash: FieldElement,
+        next_cert: WithdrawalCertificateData,
+        curr_cert: WithdrawalCertificateData,
+        next_cert_path: ScCommitmentCertPath,
+        curr_cert_path: ScCommitmentCertPath,
+        msg_path: GingerMHTBinaryPath,
+    ) -> Self {
+        assert_eq!(
+            next_cert.custom_fields.len(),
+            curr_cert.custom_fields.len(),
+            "Certificates should contains the same custom fields"
+        );
+        assert!(next_cert.custom_fields.len() >= 3, "We need at least 3 custom fields: see 
+            https://github.com/HorizenOfficial/ZenIPs/blob/57fe28cb13202550ed29512f913de2508877dc0b/zenip-42205.md#zenip-42205
+            for more detteils");
+
+        Self {
+            next_sc_tx_commitments_root,
+            curr_sc_tx_commitments_root,
+            msg_hash,
+            next_cert,
+            curr_cert,
+            next_cert_path,
+            curr_cert_path,
+            msg_path,
+        }
+    }
+
+    /// Return a default instance that can be used for setup
+    pub fn get_instance_for_setup(num_custom_fields: u32) -> Self {
+        Self {
+            next_sc_tx_commitments_root: FieldElement::zero(),
+            curr_sc_tx_commitments_root: FieldElement::zero(),
+            msg_hash: FieldElement::zero(),
+            next_cert: WithdrawalCertificateData::get_default(num_custom_fields),
+            curr_cert: WithdrawalCertificateData::get_default(num_custom_fields),
+            next_cert_path: ScCommitmentCertPath::default(),
+            curr_cert_path: ScCommitmentCertPath::default(),
+            msg_path: GingerMHTBinaryPath::new(vec![
+                (FieldElement::default(), false);
+                MSG_MT_HEIGHT
+            ]),
+        }
+    }
+
+    fn enforce_contiguos_epochs<CS>(
+        &self,
+        cs: &mut CS,
+        curr_cert_g: &WithdrawalCertificateDataGadget,
+        next_cert_g: &WithdrawalCertificateDataGadget,
+    ) -> Result<(), r1cs_core::SynthesisError>
+    where
+        CS: r1cs_core::ConstraintSystemAbstract<FieldElement>,
+    {
+        let next_epoch_id_g = {
+            let bits = next_cert_g.epoch_id_g.clone().into_bits_be();
+            FieldElementGadget::from_bits(cs.ns(|| "next_epoch_id_g"), bits.as_slice())
+        }?;
+        let curr_epoch_id_g = {
+            let bits = curr_cert_g.epoch_id_g.clone().into_bits_be();
+            FieldElementGadget::from_bits(cs.ns(|| "curr_epoch_id_g"), bits.as_slice())
+        }?;
+        curr_epoch_id_g
+            .add_constant(cs.ns(|| "curr_epoch_id + 1"), &Field::one())?
+            .enforce_equal(
+                cs.ns(|| "require(curr_cert.epoch + 1 == next_cert.epoch)"),
+                &next_epoch_id_g,
+            )?;
+        Ok(())
+    }
+
+    fn enforce_message_path<CS>(
+        self,
+        cs: &mut CS,
+        msg_hash_g: &FieldElementGadget,
+        msg_root_g: &FieldElementGadget,
+    ) -> Result<(), r1cs_core::SynthesisError>
+    where
+        CS: r1cs_core::ConstraintSystemAbstract<FieldElement>,
+    {
+        GingerMHTBinaryGadget::alloc(cs.ns(|| "alloc messages tree path"), || {
+            Ok(self.msg_path.clone())
+        })?
+        .enforce_root_from_leaf(
+            cs.ns(|| "reconstruct_merkle_root_hash(msg_hash, msg_path)"),
+            msg_hash_g,
+        )?
+        .enforce_equal(
+            cs.ns(|| {
+                "Verify merkle root of (msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root"
+            }),
+            msg_root_g,
+        )?;
+        Ok(())
+    }
+}
+
+impl ConstraintSynthesizer<FieldElement> for Sc2Sc {
+    fn generate_constraints<CS: r1cs_core::ConstraintSystemAbstract<FieldElement>>(
+        self,
+        cs: &mut CS,
+    ) -> Result<(), r1cs_core::SynthesisError> {
+        // Expose public inputs
+        let next_sc_tx_commitments_root_g =
+            FieldElementGadget::alloc_input(cs.ns(|| "Alloc next sc tx commitment root"), || {
+                Ok(self.next_sc_tx_commitments_root)
+            })?;
+        let curr_sc_tx_commitments_root_g = FieldElementGadget::alloc_input(
+            cs.ns(|| "Alloc current sc tx commitment root"),
+            || Ok(self.curr_sc_tx_commitments_root),
+        )?;
+        let msg_hash_g =
+            FieldElementGadget::alloc_input(cs.ns(|| "Alloc msg_hash"), || Ok(self.msg_hash))?;
+
+        // Alloc Withdraw certificate gadgets
+        let next_cert_g =
+            WithdrawalCertificateDataGadget::alloc(cs.ns(|| "alloc next wcert data"), || {
+                Ok(self.next_cert.clone())
+            })?;
+        let curr_cert_g =
+            WithdrawalCertificateDataGadget::alloc(cs.ns(|| "alloc current wcert data"), || {
+                Ok(self.curr_cert.clone())
+            })?;
+        // Enforce certificates hashes
+        let curr_cert_hash_g =
+            curr_cert_g.enforce_hash(cs.ns(|| "enforce current certificate hash"), None)?;
+        let next_cert_hash_g =
+            next_cert_g.enforce_hash(cs.ns(|| "enforce next certificate hash"), None)?;
+
+        // Enforce next certificate top quality hash == current certificate hash
+        next_cert_g.custom_fields_g[MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS].enforce_equal(
+            cs.ns(|| "require(next_cert.previous_top_quality_hash == H(curr_cert_hash)"),
+            &curr_cert_hash_g,
+        )?;
+
+        // Enforce current certificate epoch id + 1 == next certificate epoch id
+        self.enforce_contiguos_epochs(cs, &curr_cert_g, &next_cert_g)?;
+
+        // Enforce merkle paths for current certificate, next certificate and message hash
+        self.curr_cert_path.enforce_sc_tx_commitment_root(cs.ns(|| "Current epoch sc_tx_commitment_root recostruction") , 
+            curr_cert_hash_g, curr_cert_g.ledger_id_g)?
+            .enforce_equal(
+                cs.ns(|| "Verify merkle root of (curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"),
+                &curr_sc_tx_commitments_root_g,
+            )?;
+
+        self.next_cert_path.enforce_sc_tx_commitment_root(cs.ns(|| "Next epoch sc_tx_commitment_root recostruction") , 
+            next_cert_hash_g, next_cert_g.ledger_id_g)?
+            .enforce_equal(
+                cs.ns(|| "Verify merkle root of (next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"),
+                &next_sc_tx_commitments_root_g,
+            )?;
+
+        self.enforce_message_path(
+            cs,
+            &msg_hash_g,
+            &curr_cert_g.custom_fields_g[MSG_ROOT_HASH_CUSTOM_FIELDS_POS],
+        )?;
+
+        Ok(())
+    }
+}
+
+/// Represent the data that we need to rebuild the sc_tx_commitment root
+/// from the widthdrawal certificate. We need
+/// - `cert_path` to recover the widthdrawal certificate root from certificate hash
+/// - `fwt_root`, `bwt_root`, `ssc` (start sidechain) to build sc_commitment with
+/// widthdrawal certificate root and passed sidechain id
+/// - sc_commitment_path to rebuild the sidechain tx commitment root
+///
+/// The method `enforce_sc_tx_commitment_root` take the certificate hash and
+/// sidechain id gadgets to enforce all the path.
+#[derive(Clone)]
+pub struct ScCommitmentCertPath {
+    cert_root: FieldElement,
+    fwt_root: FieldElement,
+    bwt_root: FieldElement,
+    ssc: FieldElement,
+    cert_path: GingerMHTBinaryPath,
+    sc_commitment_path: GingerMHTBinaryPath,
+}
+
+impl Default for ScCommitmentCertPath {
+    fn default() -> Self {
+        Self {
+            cert_root: FieldElement::zero(),
+            fwt_root: FieldElement::zero(),
+            bwt_root: FieldElement::zero(),
+            ssc: FieldElement::zero(),
+            cert_path: GingerMHTBinaryPath::new(vec![Default::default(); CERT_MT_HEIGHT]),
+            sc_commitment_path: GingerMHTBinaryPath::new(vec![Default::default(); CMT_MT_HEIGHT]),
+        }
+    }
+}
+
+impl ScCommitmentCertPath {
+    /// Create a new path
+    pub fn new(
+        cert_root: FieldElement,
+        fwt_root: FieldElement,
+        bwt_root: FieldElement,
+        ssc: FieldElement,
+        cert_path: GingerMHTBinaryPath,
+        sc_commitment_path: GingerMHTBinaryPath,
+    ) -> Self {
+        Self {
+            cert_root,
+            fwt_root,
+            bwt_root,
+            ssc,
+            cert_path,
+            sc_commitment_path,
+        }
+    }
+
+    /// Recostruct the root of sc tx commitment tree and return a gadget for the enforced
+    /// root. Need the certificate hash leaf gadget in the widthdrawal certificates merkle tree
+    /// and the sidechain id gadget that we can take from the widthdrawal certificate gadget.
+    fn enforce_sc_tx_commitment_root<CS: r1cs_core::ConstraintSystemAbstract<FieldElement>>(
+        &self,
+        mut cs: CS,
+        cert_hash_g: FpGadget<FieldElement>,
+        sc_id_g: FpGadget<FieldElement>,
+    ) -> Result<FpGadget<FieldElement>, r1cs_core::SynthesisError> {
+        let cert_root_g =
+            FieldElementGadget::alloc(cs.ns(|| "alloc wcert root gadget"), || Ok(self.cert_root))?;
+        let fwt_root_g =
+            FieldElementGadget::alloc(cs.ns(|| "alloc fwt root gadget"), || Ok(self.fwt_root))?;
+        let bwt_root_g =
+            FieldElementGadget::alloc(cs.ns(|| "alloc bwt root gadget"), || Ok(self.bwt_root))?;
+        let ssc_g = FieldElementGadget::alloc(cs.ns(|| "alloc start sc gadget"), || Ok(self.ssc))?;
+        GingerMHTBinaryGadget::alloc(cs.ns(|| "alloc cert tree path"), || {
+            Ok(self.cert_path.clone())
+        })?
+        .enforce_root_from_leaf(
+            cs.ns(|| "reconstruct_merkle_root_hash(cert_hash, cert_path)"),
+            &cert_hash_g,
+        )?
+        .enforce_equal(
+            cs.ns(|| "Verify merkle root of (cert_hash, cert_path) == cert_root"),
+            &cert_root_g,
+        )?;
+
+        let sc_tx_commitment_g = FieldHashGadget::enforce_hash_constant_length(
+            cs.ns(|| "Enforce H(fwt_mr, bwt_mr, cert_mr, scc, sc_id)"),
+            &[fwt_root_g, bwt_root_g, cert_root_g, ssc_g, sc_id_g],
+        )?;
+        GingerMHTBinaryGadget::alloc(cs.ns(|| "alloc sc_tx_commitments tree path"), || {
+            Ok(self.sc_commitment_path.clone())
+        })?
+        .enforce_root_from_leaf(
+            cs.ns(|| {
+                "reconstruct_merkle_root_hash(sc_tx_commitments_root, sc_tx_commitments_path)"
+            }),
+            &sc_tx_commitment_g,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -348,6 +348,21 @@ impl ScCommitmentCertPath {
         )
         .into())
     }
+
+    pub fn update_sc_commitment_path(
+        &mut self,
+        sc_commitment_path: GingerMHTBinaryPath,
+    ) -> Result<(), Error> {
+        let length = sc_commitment_path.get_length();
+        if length != CMT_MT_HEIGHT {
+            Err(format!(
+                "Invalid path length {} != {} [height of the tree]",
+                length, CMT_MT_HEIGHT
+            ))?
+        }
+        self.sc_commitment_path = sc_commitment_path;
+        Ok(())
+    }
 }
 
 impl SemanticallyValid for ScCommitmentCertPath {

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -69,9 +69,9 @@ impl Sc2Sc {
             curr_cert.custom_fields.len(),
             "Certificates should contains the same custom fields"
         );
-        assert!(next_cert.custom_fields.len() >= MIN_CUSTOM_FIELDS, "We need at least 3 custom fields: see 
+        assert!(next_cert.custom_fields.len() >= MIN_CUSTOM_FIELDS, "We need at least {} custom fields: see 
             https://github.com/HorizenOfficial/ZenIPs/blob/57fe28cb13202550ed29512f913de2508877dc0b/zenip-42205.md#zenip-42205
-            for more details");
+            for more details", MIN_CUSTOM_FIELDS);
 
         Self {
             next_sc_tx_commitments_root,
@@ -87,19 +87,16 @@ impl Sc2Sc {
 
     /// Return a default instance that can be used for setup
     pub fn get_instance_for_setup(num_custom_fields: u32) -> Self {
-        Self {
-            next_sc_tx_commitments_root: FieldElement::zero(),
-            curr_sc_tx_commitments_root: FieldElement::zero(),
-            msg_hash: FieldElement::zero(),
-            next_cert: WithdrawalCertificateData::get_default(num_custom_fields),
-            curr_cert: WithdrawalCertificateData::get_default(num_custom_fields),
-            next_cert_path: ScCommitmentCertPath::default(),
-            curr_cert_path: ScCommitmentCertPath::default(),
-            msg_path: GingerMHTBinaryPath::new(vec![
-                (FieldElement::default(), false);
-                MSG_MT_HEIGHT
-            ]),
-        }
+        Self::new(
+            FieldElement::zero(),
+            FieldElement::zero(),
+            FieldElement::zero(),
+            WithdrawalCertificateData::get_default(num_custom_fields),
+            WithdrawalCertificateData::get_default(num_custom_fields),
+            ScCommitmentCertPath::default(),
+            ScCommitmentCertPath::default(),
+            GingerMHTBinaryPath::new(vec![(FieldElement::default(), false); MSG_MT_HEIGHT]),
+        )
     }
 
     fn enforce_contiguos_epochs<CS>(
@@ -155,7 +152,7 @@ impl ConstraintSynthesizer<FieldElement> for Sc2Sc {
             WithdrawalCertificateDataGadget::alloc(cs.ns(|| "alloc next wcert data"), || {
                 Ok(self.next_cert.clone())
             })?;
-        
+
         // Enforce certificates hashes
         let curr_cert_hash_g =
             curr_cert_g.enforce_hash(cs.ns(|| "enforce current certificate hash"), None)?;

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -210,10 +210,10 @@ impl ConstraintSynthesizer<FieldElement> for Sc2Sc {
 }
 
 /// Represent the data that we need to rebuild the sc_tx_commitment root
-/// from the widthdrawal certificate. We need
-/// - `cert_path` to recover the widthdrawal certificate root from certificate hash
+/// from the withdrawal certificate. We need
+/// - `cert_path` to recover the withdrawal certificate root from certificate hash
 /// - `fwt_root`, `bwt_root`, `ssc` (start sidechain) to build sc_commitment with
-/// widthdrawal certificate root and passed sidechain id
+/// withdrawal certificate root and passed sidechain id
 /// - sc_commitment_path to rebuild the sidechain tx commitment root
 ///
 /// The method `enforce_sc_tx_commitment_root` take the certificate hash and
@@ -270,8 +270,8 @@ struct ScCommitmentCertPathGadget {
 impl ScCommitmentCertPathGadget {
     /// Recostruct and verify the root of sc tx commitment tree. Need follow gadgets:
     /// -`sc_tx_commitment_root` the final sc tx commitment root
-    /// -`cert_hash` the certificate hash leaf gadget in the widthdrawal certificates merkle tree
-    /// -`sc_id` the sidechain id gadget that we can take from the widthdrawal certificate gadget
+    /// -`cert_hash` the certificate hash leaf gadget in the withdrawal certificates merkle tree
+    /// -`sc_id` the sidechain id gadget that we can take from the withdrawal certificate gadget
     fn check_membership<CS: r1cs_core::ConstraintSystemAbstract<FieldElement>>(
         &self,
         mut cs: CS,

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 
 /// The height of the Messages Merkle Tree in the current epoch
 /// TODO: move it in cctp-lib
-pub const MSG_MT_HEIGHT: usize = 12;
+pub const MSG_MT_HEIGHT: usize = 16;
 
 #[derive(Clone)]
 pub struct Sc2Sc {

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -1,9 +1,14 @@
-use std::borrow::Borrow;
+use std::{borrow::Borrow, convert::TryInto};
 
-use algebra::Field;
+use algebra::{
+    CanonicalDeserialize, CanonicalSerialize, Error, Field, Read, SemanticallyValid,
+    SerializationError, Write,
+};
 use cctp_primitives::{
-    commitment_tree::{sidechain_tree_alive::CERT_MT_HEIGHT, CMT_MT_HEIGHT},
+    commitment_tree::{sidechain_tree_alive::CERT_MT_HEIGHT, CommitmentTree, CMT_MT_HEIGHT},
+    proving_system::verifier::UserInputs,
     type_mapping::FieldElement,
+    utils::commitment_tree::hash_vec,
 };
 use primitives::FieldBasedMerkleTreePath;
 use r1cs_core::ConstraintSynthesizer;
@@ -30,12 +35,7 @@ pub const MSG_MT_HEIGHT: usize = 16;
 #[derive(Clone)]
 pub struct Sc2Sc {
     // Public Inputs
-    /// Side Chain Tx Commitment  Root of epoch N+1
-    next_sc_tx_commitments_root: FieldElement,
-    /// Side Chain Tx Commitment  Root of epoch N
-    curr_sc_tx_commitments_root: FieldElement,
-    /// Hash of the message to be redeemed
-    msg_hash: FieldElement,
+    public_input: Sc2ScUserInput,
 
     // Witnesses
     /// Certificate of epoch N+1
@@ -74,9 +74,11 @@ impl Sc2Sc {
             for more details", MIN_CUSTOM_FIELDS);
 
         Self {
-            next_sc_tx_commitments_root,
-            curr_sc_tx_commitments_root,
-            msg_hash,
+            public_input: Sc2ScUserInput::new(
+                next_sc_tx_commitments_root,
+                curr_sc_tx_commitments_root,
+                msg_hash,
+            ),
             next_cert,
             curr_cert,
             next_cert_path,
@@ -97,6 +99,10 @@ impl Sc2Sc {
             ScCommitmentCertPath::default(),
             GingerMHTBinaryPath::new(vec![(FieldElement::default(), false); MSG_MT_HEIGHT]),
         )
+    }
+
+    pub fn public_input(&self) -> &Sc2ScUserInput {
+        &self.public_input
     }
 
     fn enforce_contiguos_epochs<CS>(
@@ -134,14 +140,15 @@ impl ConstraintSynthesizer<FieldElement> for Sc2Sc {
         // Expose public inputs
         let next_sc_tx_commitments_root_g =
             FieldElementGadget::alloc_input(cs.ns(|| "Alloc next sc tx commitment root"), || {
-                Ok(self.next_sc_tx_commitments_root)
+                Ok(self.public_input.next_sc_tx_commitments_root)
             })?;
         let curr_sc_tx_commitments_root_g = FieldElementGadget::alloc_input(
             cs.ns(|| "Alloc current sc tx commitment root"),
-            || Ok(self.curr_sc_tx_commitments_root),
+            || Ok(self.public_input.curr_sc_tx_commitments_root),
         )?;
-        let msg_hash_g =
-            FieldElementGadget::alloc_input(cs.ns(|| "Alloc msg_hash"), || Ok(self.msg_hash))?;
+        let msg_hash_g = FieldElementGadget::alloc_input(cs.ns(|| "Alloc msg_hash"), || {
+            Ok(self.public_input.msg_hash)
+        })?;
 
         // Alloc Withdraw certificate gadgets
         let curr_cert_g =
@@ -206,6 +213,43 @@ impl ConstraintSynthesizer<FieldElement> for Sc2Sc {
     }
 }
 
+#[derive(Default, Clone, Debug)]
+pub struct Sc2ScUserInput {
+    // Public Inputs
+    /// Side Chain Tx Commitment  Root of epoch N+1
+    next_sc_tx_commitments_root: FieldElement,
+    /// Side Chain Tx Commitment  Root of epoch N
+    curr_sc_tx_commitments_root: FieldElement,
+    /// Hash of the message to be redeemed
+    msg_hash: FieldElement,
+}
+
+impl Sc2ScUserInput {
+    pub fn new(
+        next_sc_tx_commitments_root: FieldElement,
+        curr_sc_tx_commitments_root: FieldElement,
+        msg_hash: FieldElement,
+    ) -> Self {
+        Self {
+            next_sc_tx_commitments_root,
+            curr_sc_tx_commitments_root,
+            msg_hash,
+        }
+    }
+}
+
+impl UserInputs for Sc2ScUserInput {
+    fn get_circuit_inputs(
+        &self,
+    ) -> Result<Vec<FieldElement>, cctp_primitives::proving_system::error::ProvingSystemError> {
+        Ok(vec![
+            self.next_sc_tx_commitments_root,
+            self.curr_sc_tx_commitments_root,
+            self.msg_hash,
+        ])
+    }
+}
+
 /// Represent the data that we need to rebuild the sc_tx_commitment root
 /// from the withdrawal certificate. We need
 /// - `cert_path` to recover the withdrawal certificate root from certificate hash
@@ -216,7 +260,7 @@ impl ConstraintSynthesizer<FieldElement> for Sc2Sc {
 /// The method `enforce_sc_tx_commitment_root` take the certificate hash and
 /// sidechain id gadgets to enforce all the path.
 // TODO: Maybe is better to move it in zendoo-cctp-cryptolib
-#[derive(Clone)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ScCommitmentCertPath {
     fwt_root: FieldElement,
     bwt_root: FieldElement,
@@ -253,6 +297,63 @@ impl ScCommitmentCertPath {
             cert_path,
             sc_commitment_path,
         }
+    }
+
+    pub fn compute_root(
+        &self,
+        sc_id: &FieldElement,
+        cert_hash: &FieldElement,
+    ) -> Result<FieldElement, Error> {
+        let cert_root = self.cert_path.compute_root(&cert_hash);
+        let commitment = hash_vec(vec![
+            self.fwt_root.clone(),
+            self.bwt_root.clone(),
+            cert_root.clone(),
+            self.ssc,
+            sc_id.clone(),
+        ])?;
+        Ok(self.sc_commitment_path.compute_root(&commitment))
+    }
+
+    pub fn check_membership(
+        &self,
+        sc_tx_commitment_root: &FieldElement,
+        sc_id: &FieldElement,
+        cert_hash: &FieldElement,
+    ) -> bool {
+        self.compute_root(sc_id, cert_hash)
+            .map(|r| &r == sc_tx_commitment_root)
+            .unwrap_or(false)
+    }
+
+    /// Add implementation to simplify the extraction from a commitment
+    pub fn from_commitment_cert_index(
+        cmt: &mut CommitmentTree,
+        sc_id: FieldElement,
+        cert_index: usize,
+    ) -> Result<Self, Error> {
+        Ok(Self::new(
+            cmt.get_fwt_commitment(&sc_id)
+                .ok_or(format!("Cannot retrive the forward transfer root"))?,
+            cmt.get_bwtr_commitment(&sc_id)
+                .ok_or(format!("Cannot retrive the backward transfer root"))?,
+            cmt.get_scc(&sc_id)
+                .ok_or(format!("Cannot retrive the sidechain creation"))?,
+            cmt.get_cert_merkle_path(&sc_id, cert_index)
+                .ok_or(format!("Cannot retrive the certificate merkle path"))?
+                .try_into()?,
+            cmt.get_sc_commitment_merkle_path(&sc_id)
+                .ok_or(format!("Cannot retrive the commitment merkle path"))?
+                .try_into()?,
+        )
+        .into())
+    }
+}
+
+impl SemanticallyValid for ScCommitmentCertPath {
+    fn is_valid(&self) -> bool {
+        self.cert_path.get_length() == CERT_MT_HEIGHT
+            && self.sc_commitment_path.get_length() == CMT_MT_HEIGHT
     }
 }
 

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -13,15 +13,13 @@ use r1cs_std::{
 };
 
 use crate::{
-    common::{constraints::WithdrawalCertificateDataGadget, WithdrawalCertificateData},
+    common::{constraints::WithdrawalCertificateDataGadget, WithdrawalCertificateData, MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS, MSG_ROOT_HASH_CUSTOM_FIELDS_POS, MIN_CUSTOM_FIELDS},
     FieldElementGadget, FieldHashGadget, GingerMHTBinaryGadget, GingerMHTBinaryPath,
 };
 
 /// The height of the Messages Merkle Tree in the current epoch
+/// TODO: move it in cctp-lib
 pub const MSG_MT_HEIGHT: usize = 12;
-pub const MIN_CUSTOM_FIELDS: usize = 3;
-pub const MSG_ROOT_HASH_CUSTOM_FIELDS_POS: usize = 1;
-pub const MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS: usize = 2;
 
 #[derive(Clone)]
 pub struct Sc2Sc {
@@ -65,7 +63,7 @@ impl Sc2Sc {
             curr_cert.custom_fields.len(),
             "Certificates should contains the same custom fields"
         );
-        assert!(next_cert.custom_fields.len() >= 3, "We need at least 3 custom fields: see 
+        assert!(next_cert.custom_fields.len() >= MIN_CUSTOM_FIELDS, "We need at least 3 custom fields: see 
             https://github.com/HorizenOfficial/ZenIPs/blob/57fe28cb13202550ed29512f913de2508877dc0b/zenip-42205.md#zenip-42205
             for more detteils");
 

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -88,7 +88,7 @@ fn base_commitments(#[default(42)] epoch: u32) -> (CommitmentScBuilder, Commitme
 #[rstest]
 #[serial]
 fn simplest_case(
-    mut rng: ThreadRng,
+    mut rng: impl Rng,
     base_commitments: CommitmentPair,
     #[values(true, false)] zk: bool,
 ) {
@@ -127,7 +127,7 @@ fn simplest_case(
 #[rstest]
 #[serial]
 fn happy_path(
-    mut rng: ThreadRng,
+    mut rng: impl Rng,
     base_commitments: CommitmentPair,
     #[values(true, false)] zk: bool,
 ) {
@@ -226,7 +226,7 @@ mod should_fail {
     #[serial]
     #[should_panic(expected = "curr_cert.epoch + 1 == next_cert.epoch")]
     fn if_not_contiguos_epochs(
-        mut rng: ThreadRng,
+        mut rng: impl Rng,
         base_commitments: CommitmentPair,
         #[values(true, false)] zk: bool,
     ) {
@@ -284,7 +284,7 @@ mod should_fail {
         expected = "Check current epoch sc_tx_commitment_root"
     )]
     fn if_invalid_current_sc_commitment_path(
-        mut rng: ThreadRng,
+        mut rng: impl Rng,
         base_commitments: CommitmentPair,
         #[values(true, false)] zk: bool,
         #[case] action: TestChangeTxPathAction,
@@ -359,7 +359,7 @@ mod should_fail {
         expected = "Check next epoch sc_tx_commitment_root"
     )]
     fn if_invalid_next_sc_commitment_path(
-        mut rng: ThreadRng,
+        mut rng: impl Rng,
         base_commitments: CommitmentPair,
         #[values(true, false)] zk: bool,
         #[case] action: TestChangeTxPathAction,
@@ -437,7 +437,7 @@ mod should_fail {
         expected = "(msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root"
     )]
     fn if_invalid_msg_data(
-        mut rng: ThreadRng,
+        mut rng: impl Rng,
         base_commitments: CommitmentPair,
         #[values(true, false)] zk: bool,
         #[case] action: TestChangeMsgAction,
@@ -487,7 +487,7 @@ mod should_fail {
     #[serial]
     #[should_panic(expected = "next_cert.previous_top_quality_hash == H(curr_cert_hash)")]
     fn if_some_in_curr_cert_change(
-        mut rng: ThreadRng,
+        mut rng: impl Rng,
         base_commitments: CommitmentPair,
         #[values(true, false)] zk: bool,
     ) {

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -223,7 +223,7 @@ mod should_not_possible_to_create_a_circuit_if {
 #[case::minimum(MIN_CUSTOM_FIELDS)]
 #[case::lot_of(MIN_CUSTOM_FIELDS + 42)]
 #[should_panic(expected = "need at least")]
-#[case::should_fail_with_less_than_3(MIN_CUSTOM_FIELDS - 1)]
+#[case::should_fail_with_less_than_minimum(MIN_CUSTOM_FIELDS - 1)]
 fn setup_a_circuit_with_some_custom_fields(#[case] n_custom_fields: usize) {
     Sc2Sc::get_instance_for_setup(n_custom_fields as u32);
 }

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -281,7 +281,7 @@ mod should_fail {
     #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
     #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
     #[should_panic(
-        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
+        expected = "Check current epoch sc_tx_commitment_root"
     )]
     fn if_invalid_current_sc_commitment_path(
         mut rng: ThreadRng,
@@ -356,7 +356,7 @@ mod should_fail {
     #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
     #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
     #[should_panic(
-        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
+        expected = "Check next epoch sc_tx_commitment_root"
     )]
     fn if_invalid_next_sc_commitment_path(
         mut rng: ThreadRng,
@@ -434,7 +434,7 @@ mod should_fail {
     #[case::path(TestChangeMsgAction::Path)]
     #[serial]
     #[should_panic(
-        expected = "(msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root/conditional_equals"
+        expected = "(msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root"
     )]
     fn if_invalid_msg_data(
         mut rng: ThreadRng,

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -102,13 +102,13 @@ fn simplest_case(
         .with_certificate_msg_root(msg_root)
         .generate_sc_data(None, &mut rng, sc_id);
     let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
-        curr.get_widthdrawal_certificate_info(0);
+        curr.get_withdrawal_certificate_info(0);
 
     let mut next = next
         .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
         .generate_sc_data(None, &mut rng, sc_id);
     let (next_cert, next_cert_path, next_sc_tx_commitment) =
-        next.get_widthdrawal_certificate_info(0);
+        next.get_withdrawal_certificate_info(0);
 
     let sc2sc = Sc2Sc::new(
         next_sc_tx_commitment,
@@ -138,19 +138,19 @@ fn happy_path(
     let (curr, next) = base_commitments;
     let curr_helper = curr
         .with_certificate_msg_root(msg_root)
-        .with_n_forward_transfert(24)
-        .with_n_backward_transfert(12)
+        .with_n_forward_transfer(24)
+        .with_n_backward_transfer(12)
         .with_n_withdrawal_certificates(3)
         .generate_sc_data(None, &mut rng, sc_id);
     let other_sc_id = rng.gen();
     // Add another sc
     let mut curr = CommitmentScBuilder::default()
-        .with_n_forward_transfert(1)
-        .with_n_backward_transfert(1)
+        .with_n_forward_transfer(1)
+        .with_n_backward_transfer(1)
         .generate_sc_data(Some(curr_helper), &mut rng, other_sc_id);
 
     let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
-        curr.get_widthdrawal_certificate_info(2);
+        curr.get_withdrawal_certificate_info(2);
 
     let next_helper = next
         .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
@@ -158,12 +158,12 @@ fn happy_path(
     let other_sc_id = rng.gen();
     // Add another sc
     let mut next = CommitmentScBuilder::default()
-        .with_n_forward_transfert(1)
-        .with_n_backward_transfert(1)
+        .with_n_forward_transfer(1)
+        .with_n_backward_transfer(1)
         .generate_sc_data(Some(next_helper), &mut rng, other_sc_id);
 
     let (next_cert, next_cert_path, next_sc_tx_commitment) =
-        next.get_widthdrawal_certificate_info(0);
+        next.get_withdrawal_certificate_info(0);
 
     let sc2sc = Sc2Sc::new(
         next_sc_tx_commitment,
@@ -240,14 +240,14 @@ mod should_fail {
             .with_certificate_msg_root(msg_root)
             .generate_sc_data(None, &mut rng, sc_id);
         let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
-            curr.get_widthdrawal_certificate_info(0);
+            curr.get_withdrawal_certificate_info(0);
 
         let mut next = next
             .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
             .with_epoch(1234) // Change next epoch
             .generate_sc_data(None, &mut rng, sc_id);
         let (next_cert, next_cert_path, next_sc_tx_commitment) =
-            next.get_widthdrawal_certificate_info(0);
+            next.get_withdrawal_certificate_info(0);
 
         let sc2sc = Sc2Sc::new(
             next_sc_tx_commitment,
@@ -275,14 +275,12 @@ mod should_fail {
     #[rstest]
     #[serial]
     #[case::sc_tx_commitment_root(TestChangeTxPathAction::ScTxCommitmentRoot)]
-    #[case::forward_transfert_root(TestChangeTxPathAction::FTRootHash)]
-    #[case::backward_transfert_root(TestChangeTxPathAction::BTRootHash)]
+    #[case::forward_transfer_root(TestChangeTxPathAction::FTRootHash)]
+    #[case::backward_transfer_root(TestChangeTxPathAction::BTRootHash)]
     #[case::start_side_chain(TestChangeTxPathAction::SSC)]
-    #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
+    #[case::withdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
     #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
-    #[should_panic(
-        expected = "Check current epoch sc_tx_commitment_root"
-    )]
+    #[should_panic(expected = "Check current epoch sc_tx_commitment_root")]
     fn if_invalid_current_sc_commitment_path(
         mut rng: impl Rng,
         base_commitments: CommitmentPair,
@@ -299,13 +297,13 @@ mod should_fail {
             .with_certificate_msg_root(msg_root)
             .generate_sc_data(None, &mut rng, sc_id);
         let (curr_cert, mut curr_cert_path, mut curr_sc_tx_commitment) =
-            curr.get_widthdrawal_certificate_info(0);
+            curr.get_withdrawal_certificate_info(0);
 
         let mut next = next
             .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
             .generate_sc_data(None, &mut rng, sc_id);
         let (next_cert, next_cert_path, next_sc_tx_commitment) =
-            next.get_widthdrawal_certificate_info(0);
+            next.get_withdrawal_certificate_info(0);
 
         use TestChangeTxPathAction::*;
         match action {
@@ -350,14 +348,12 @@ mod should_fail {
     #[rstest]
     #[serial]
     #[case::sc_tx_commitment_root(TestChangeTxPathAction::ScTxCommitmentRoot)]
-    #[case::forward_transfert_root(TestChangeTxPathAction::FTRootHash)]
-    #[case::backward_transfert_root(TestChangeTxPathAction::BTRootHash)]
+    #[case::forward_transfer_root(TestChangeTxPathAction::FTRootHash)]
+    #[case::backward_transfer_root(TestChangeTxPathAction::BTRootHash)]
     #[case::start_side_chain(TestChangeTxPathAction::SSC)]
-    #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
+    #[case::withdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
     #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
-    #[should_panic(
-        expected = "Check next epoch sc_tx_commitment_root"
-    )]
+    #[should_panic(expected = "Check next epoch sc_tx_commitment_root")]
     fn if_invalid_next_sc_commitment_path(
         mut rng: impl Rng,
         base_commitments: CommitmentPair,
@@ -374,13 +370,13 @@ mod should_fail {
             .with_certificate_msg_root(msg_root)
             .generate_sc_data(None, &mut rng, sc_id);
         let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
-            curr.get_widthdrawal_certificate_info(0);
+            curr.get_withdrawal_certificate_info(0);
 
         let mut next = next
             .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
             .generate_sc_data(None, &mut rng, sc_id);
         let (next_cert, mut next_cert_path, mut next_sc_tx_commitment) =
-            next.get_widthdrawal_certificate_info(0);
+            next.get_withdrawal_certificate_info(0);
 
         use TestChangeTxPathAction::*;
         match action {
@@ -433,9 +429,7 @@ mod should_fail {
     #[case::hash(TestChangeMsgAction::Hash)]
     #[case::path(TestChangeMsgAction::Path)]
     #[serial]
-    #[should_panic(
-        expected = "(msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root"
-    )]
+    #[should_panic(expected = "(msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root")]
     fn if_invalid_msg_data(
         mut rng: impl Rng,
         base_commitments: CommitmentPair,
@@ -461,13 +455,13 @@ mod should_fail {
             .with_certificate_msg_root(msg_root)
             .generate_sc_data(None, &mut rng, sc_id);
         let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
-            curr.get_widthdrawal_certificate_info(0);
+            curr.get_withdrawal_certificate_info(0);
 
         let mut next = next
             .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
             .generate_sc_data(None, &mut rng, sc_id);
         let (next_cert, next_cert_path, next_sc_tx_commitment) =
-            next.get_widthdrawal_certificate_info(0);
+            next.get_withdrawal_certificate_info(0);
 
         let sc2sc = Sc2Sc::new(
             next_sc_tx_commitment,
@@ -501,13 +495,13 @@ mod should_fail {
             .with_certificate_msg_root(msg_root)
             .generate_sc_data(None, &mut rng, sc_id);
         let (mut curr_cert, curr_cert_path, curr_sc_tx_commitment) =
-            curr.get_widthdrawal_certificate_info(0);
+            curr.get_withdrawal_certificate_info(0);
 
         let mut next = next
             .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
             .generate_sc_data(None, &mut rng, sc_id);
         let (next_cert, next_cert_path, next_sc_tx_commitment) =
-            next.get_widthdrawal_certificate_info(0);
+            next.get_withdrawal_certificate_info(0);
 
         curr_cert.btr_min_fee += 1;
 

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -1,0 +1,565 @@
+use std::convert::TryInto;
+
+use algebra::Field;
+use cctp_primitives::{
+    commitment_tree::CommitmentTree,
+    type_mapping::{CoboundaryMarlin, FieldElement},
+};
+
+use primitives::FieldBasedMerkleTreePath;
+use r1cs_core::debug_circuit;
+use rand::{rngs::ThreadRng, thread_rng, Rng, RngCore};
+use rstest::*;
+use serial_test::serial;
+
+use crate::{
+    test_utils::{
+        self, init_g1_committer_key, CommitmentScBuilder, RandomWithdrawalCertificateDataBuilder,
+    },
+    GingerMHTBinaryPath,
+};
+
+use super::{Sc2Sc, ScCommitmentCertPath, MIN_CUSTOM_FIELDS, MSG_MT_HEIGHT};
+
+impl ScCommitmentCertPath {
+    /// Add implementation to simplify the extraction from a commitment
+    pub(crate) fn from_commitment(
+        cmt: &mut CommitmentTree,
+        sc_id: FieldElement,
+        cert_hash: FieldElement,
+    ) -> Option<Self> {
+        let cert_index = cmt
+            .get_cert_leaves(&sc_id)
+            .and_then(|certs| certs.iter().position(|h| h == &cert_hash))?;
+        Self::new(
+            cmt.get_cert_commitment(&sc_id)?,
+            cmt.get_fwt_commitment(&sc_id)?,
+            cmt.get_bwtr_commitment(&sc_id)?,
+            cmt.get_scc(&sc_id)?,
+            cmt.get_cert_merkle_path(&sc_id, cert_index)
+                .map(|p| p.try_into().expect("Should be a binary tree"))?,
+            cmt.get_sc_commitment_merkle_path(&sc_id)
+                .map(|p| p.try_into().expect("Should be a binary tree"))?,
+        )
+        .into()
+    }
+}
+
+fn assert_circuit(circuit: Sc2Sc, zk_rng: Option<&mut dyn RngCore>) {
+    let ck_g1 = init_g1_committer_key();
+    let setup_circuit = Sc2Sc::get_instance_for_setup(MIN_CUSTOM_FIELDS as u32);
+    let (pk, vk) = CoboundaryMarlin::index(&ck_g1, setup_circuit).unwrap();
+
+    assert_eq!(None, debug_circuit(circuit.clone()).unwrap());
+    let proof =
+        CoboundaryMarlin::prove(&pk, &ck_g1, circuit.clone(), zk_rng.is_some(), zk_rng).unwrap();
+    let public_inputs = [
+        circuit.next_sc_tx_commitments_root,
+        circuit.curr_sc_tx_commitments_root,
+        circuit.msg_hash,
+    ];
+    assert!(CoboundaryMarlin::verify(&vk, &ck_g1, &public_inputs, &proof).unwrap());
+}
+
+#[fixture]
+fn rng() -> ThreadRng {
+    thread_rng()
+}
+
+type CommitmentPair = (CommitmentScBuilder, CommitmentScBuilder);
+
+#[fixture]
+fn base_commitments(#[default(42)] epoch: u32) -> (CommitmentScBuilder, CommitmentScBuilder) {
+    let curr_cmt = CommitmentScBuilder::default()
+        .with_epoch(epoch)
+        .with_n_withdrawal_certificates(1)
+        .with_certificates_builder(RandomWithdrawalCertificateDataBuilder::new(
+            MIN_CUSTOM_FIELDS,
+        ));
+    let next_cmt = CommitmentScBuilder::default()
+        .with_epoch(epoch + 1)
+        .with_n_withdrawal_certificates(1)
+        .with_certificates_builder(RandomWithdrawalCertificateDataBuilder::new(
+            MIN_CUSTOM_FIELDS,
+        ));
+
+    (curr_cmt, next_cmt)
+}
+
+#[rstest]
+#[serial]
+fn simplest_case(
+    mut rng: ThreadRng,
+    base_commitments: CommitmentPair,
+    #[values(true, false)] zk: bool,
+) {
+    let sc_id: FieldElement = rng.gen();
+    // Just one message in the root
+    let (msg_root, msg_hash, msg_path) = test_utils::messages(&mut rng, 1, 0);
+
+    let (curr, next) = base_commitments;
+
+    let mut curr = curr
+        .with_certificate_msg_root(msg_root)
+        .generate_sc_data(None, &mut rng, sc_id);
+    let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
+        curr.get_widthdrawal_certificate_info(0);
+
+    let mut next = next
+        .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+        .generate_sc_data(None, &mut rng, sc_id);
+    let (next_cert, next_cert_path, next_sc_tx_commitment) =
+        next.get_widthdrawal_certificate_info(0);
+
+    let sc2sc = Sc2Sc::new(
+        next_sc_tx_commitment,
+        curr_sc_tx_commitment,
+        msg_hash,
+        next_cert,
+        curr_cert,
+        next_cert_path,
+        curr_cert_path,
+        msg_path,
+    );
+
+    assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+}
+
+#[rstest]
+#[serial]
+fn happy_path(
+    mut rng: ThreadRng,
+    base_commitments: CommitmentPair,
+    #[values(true, false)] zk: bool,
+) {
+    // In this case we add some other data and more sidechains in both curr and next
+    let sc_id: FieldElement = rng.gen();
+    let (msg_root, msg_hash, msg_path) = test_utils::messages(&mut rng, 22, 4);
+
+    let (curr, next) = base_commitments;
+    let curr_helper = curr
+        .with_certificate_msg_root(msg_root)
+        .with_n_forward_transfert(24)
+        .with_n_backward_transfert(12)
+        .with_n_withdrawal_certificates(3)
+        .generate_sc_data(None, &mut rng, sc_id);
+    let other_sc_id = rng.gen();
+    // Add another sc
+    let mut curr = CommitmentScBuilder::default()
+        .with_n_forward_transfert(1)
+        .with_n_backward_transfert(1)
+        .generate_sc_data(Some(curr_helper), &mut rng, other_sc_id);
+
+    let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
+        curr.get_widthdrawal_certificate_info(2);
+
+    let next_helper = next
+        .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+        .generate_sc_data(None, &mut rng, sc_id);
+    let other_sc_id = rng.gen();
+    // Add another sc
+    let mut next = CommitmentScBuilder::default()
+        .with_n_forward_transfert(1)
+        .with_n_backward_transfert(1)
+        .generate_sc_data(Some(next_helper), &mut rng, other_sc_id);
+
+    let (next_cert, next_cert_path, next_sc_tx_commitment) =
+        next.get_widthdrawal_certificate_info(0);
+
+    let sc2sc = Sc2Sc::new(
+        next_sc_tx_commitment,
+        curr_sc_tx_commitment,
+        msg_hash,
+        next_cert,
+        curr_cert,
+        next_cert_path,
+        curr_cert_path,
+        msg_path,
+    );
+
+    assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+}
+
+mod should_not_possible_to_add_a_circuit_if {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "same custom fields")]
+    fn certificates_have_not_the_same_numbers_of_custom_fields() {
+        let curr_cert = RandomWithdrawalCertificateDataBuilder::new(3).build();
+        let next_cert = RandomWithdrawalCertificateDataBuilder::new(4).build();
+
+        Sc2Sc::new(
+            FieldElement::zero(),
+            FieldElement::zero(),
+            FieldElement::zero(),
+            next_cert,
+            curr_cert,
+            ScCommitmentCertPath::default(),
+            ScCommitmentCertPath::default(),
+            GingerMHTBinaryPath::new(vec![(FieldElement::default(), false); MSG_MT_HEIGHT]),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "least 3 custom fields")]
+    fn certificates_have_less_than_3_custom_fields() {
+        let curr_cert = RandomWithdrawalCertificateDataBuilder::new(2).build();
+        let next_cert = RandomWithdrawalCertificateDataBuilder::new(2).build();
+
+        Sc2Sc::new(
+            FieldElement::zero(),
+            FieldElement::zero(),
+            FieldElement::zero(),
+            next_cert,
+            curr_cert,
+            ScCommitmentCertPath::default(),
+            ScCommitmentCertPath::default(),
+            GingerMHTBinaryPath::new(vec![(FieldElement::default(), false); MSG_MT_HEIGHT]),
+        );
+    }
+}
+
+mod should_fail {
+    use super::*;
+
+    #[rstest]
+    #[serial]
+    #[should_panic(expected = "curr_cert.epoch + 1 == next_cert.epoch")]
+    fn if_not_contiguos_epochs(
+        mut rng: ThreadRng,
+        base_commitments: CommitmentPair,
+        #[values(true, false)] zk: bool,
+    ) {
+        let sc_id: FieldElement = rng.gen();
+        // Just one message in the root
+        let (msg_root, msg_hash, msg_path) = test_utils::messages(&mut rng, 1, 0);
+
+        let (curr, next) = base_commitments;
+
+        let mut curr = curr
+            .with_certificate_msg_root(msg_root)
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
+            curr.get_widthdrawal_certificate_info(0);
+
+        let mut next = next
+            .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+            .with_epoch(1234) // Change next epoch
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (next_cert, next_cert_path, next_sc_tx_commitment) =
+            next.get_widthdrawal_certificate_info(0);
+
+        let sc2sc = Sc2Sc::new(
+            next_sc_tx_commitment,
+            curr_sc_tx_commitment,
+            msg_hash,
+            next_cert,
+            curr_cert,
+            next_cert_path,
+            curr_cert_path,
+            msg_path,
+        );
+
+        assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+    }
+
+    enum TestChangeTxPathAction {
+        ScTxCommitmentRoot,
+        FTRootHash,
+        BTRootHash,
+        WCertRoot,
+        SSC,
+        CertPath,
+        ScCommitmentPath,
+    }
+
+    #[rstest]
+    #[serial]
+    #[should_panic(
+        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
+    )]
+    #[case::sc_tx_commitment_root(TestChangeTxPathAction::ScTxCommitmentRoot)]
+    #[should_panic(expected = "Current epoch sc_tx_commitment_root recostruction")]
+    #[case::widthdrawal_certificate_root(TestChangeTxPathAction::WCertRoot)]
+    #[should_panic(
+        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
+    )]
+    #[case::forward_transfert_root(TestChangeTxPathAction::FTRootHash)]
+    #[should_panic(
+        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
+    )]
+    #[case::backward_transfert_root(TestChangeTxPathAction::BTRootHash)]
+    #[should_panic(
+        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
+    )]
+    #[case::start_side_chain(TestChangeTxPathAction::SSC)]
+    #[should_panic(expected = "Current epoch sc_tx_commitment_root recostruction")]
+    #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
+    #[should_panic(
+        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
+    )]
+    #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
+    fn if_invalid_current_sc_commitment_path(
+        mut rng: ThreadRng,
+        base_commitments: CommitmentPair,
+        #[values(true, false)] zk: bool,
+        #[case] action: TestChangeTxPathAction,
+    ) {
+        let sc_id: FieldElement = rng.gen();
+        // Just one message in the root
+        let (msg_root, msg_hash, msg_path) = test_utils::messages(&mut rng, 1, 0);
+
+        let (curr, next) = base_commitments;
+
+        let mut curr = curr
+            .with_certificate_msg_root(msg_root)
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (curr_cert, mut curr_cert_path, mut curr_sc_tx_commitment) =
+            curr.get_widthdrawal_certificate_info(0);
+
+        let mut next = next
+            .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (next_cert, next_cert_path, next_sc_tx_commitment) =
+            next.get_widthdrawal_certificate_info(0);
+
+        use TestChangeTxPathAction::*;
+        match action {
+            ScTxCommitmentRoot => {
+                curr_sc_tx_commitment += FieldElement::one();
+            }
+            WCertRoot => {
+                curr_cert_path.cert_root += FieldElement::one();
+            }
+            FTRootHash => {
+                curr_cert_path.fwt_root += FieldElement::one();
+            }
+            BTRootHash => {
+                curr_cert_path.bwt_root += FieldElement::one();
+            }
+            SSC => {
+                curr_cert_path.ssc += FieldElement::one();
+            }
+            CertPath => {
+                let mut raw = curr_cert_path.cert_path.get_raw_path().clone();
+                raw[0].0 += FieldElement::one();
+                curr_cert_path.cert_path = GingerMHTBinaryPath::new(raw);
+            }
+            ScCommitmentPath => {
+                let mut raw = curr_cert_path.sc_commitment_path.get_raw_path().clone();
+                raw[0].0 += FieldElement::one();
+                curr_cert_path.sc_commitment_path = GingerMHTBinaryPath::new(raw);
+            }
+        }
+
+        let sc2sc = Sc2Sc::new(
+            next_sc_tx_commitment,
+            curr_sc_tx_commitment,
+            msg_hash,
+            next_cert,
+            curr_cert,
+            next_cert_path,
+            curr_cert_path,
+            msg_path,
+        );
+
+        assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+    }
+
+    #[rstest]
+    #[serial]
+    #[should_panic(
+        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
+    )]
+    #[case::sc_tx_commitment_root(TestChangeTxPathAction::ScTxCommitmentRoot)]
+    #[should_panic(expected = "Next epoch sc_tx_commitment_root recostruction")]
+    #[case::widthdrawal_certificate_root(TestChangeTxPathAction::WCertRoot)]
+    #[should_panic(
+        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
+    )]
+    #[case::forward_transfert_root(TestChangeTxPathAction::FTRootHash)]
+    #[should_panic(
+        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
+    )]
+    #[case::backward_transfert_root(TestChangeTxPathAction::BTRootHash)]
+    #[should_panic(
+        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
+    )]
+    #[case::start_side_chain(TestChangeTxPathAction::SSC)]
+    #[should_panic(expected = "Next epoch sc_tx_commitment_root recostruction")]
+    #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
+    #[should_panic(
+        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
+    )]
+    #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
+    fn if_invalid_next_sc_commitment_path(
+        mut rng: ThreadRng,
+        base_commitments: CommitmentPair,
+        #[values(true, false)] zk: bool,
+        #[case] action: TestChangeTxPathAction,
+    ) {
+        let sc_id: FieldElement = rng.gen();
+        // Just one message in the root
+        let (msg_root, msg_hash, msg_path) = test_utils::messages(&mut rng, 1, 0);
+
+        let (curr, next) = base_commitments;
+
+        let mut curr = curr
+            .with_certificate_msg_root(msg_root)
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
+            curr.get_widthdrawal_certificate_info(0);
+
+        let mut next = next
+            .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (next_cert, mut next_cert_path, mut next_sc_tx_commitment) =
+            next.get_widthdrawal_certificate_info(0);
+
+        use TestChangeTxPathAction::*;
+        match action {
+            ScTxCommitmentRoot => {
+                next_sc_tx_commitment += FieldElement::one();
+            }
+            WCertRoot => {
+                next_cert_path.cert_root += FieldElement::one();
+            }
+            FTRootHash => {
+                next_cert_path.fwt_root += FieldElement::one();
+            }
+            BTRootHash => {
+                next_cert_path.bwt_root += FieldElement::one();
+            }
+            SSC => {
+                next_cert_path.ssc += FieldElement::one();
+            }
+            CertPath => {
+                let mut raw = curr_cert_path.cert_path.get_raw_path().clone();
+                raw[0].0 += FieldElement::one();
+                next_cert_path.cert_path = GingerMHTBinaryPath::new(raw);
+            }
+            ScCommitmentPath => {
+                let mut raw = curr_cert_path.sc_commitment_path.get_raw_path().clone();
+                raw[0].0 += FieldElement::one();
+                next_cert_path.sc_commitment_path = GingerMHTBinaryPath::new(raw);
+            }
+        }
+
+        let sc2sc = Sc2Sc::new(
+            next_sc_tx_commitment,
+            curr_sc_tx_commitment,
+            msg_hash,
+            next_cert,
+            curr_cert,
+            next_cert_path,
+            curr_cert_path,
+            msg_path,
+        );
+
+        assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+    }
+
+    enum TestChangeMsgAction {
+        Root,
+        Hash,
+        Path,
+    }
+
+    #[rstest]
+    #[case::root(TestChangeMsgAction::Root)]
+    #[case::hash(TestChangeMsgAction::Hash)]
+    #[case::path(TestChangeMsgAction::Path)]
+    #[serial]
+    #[should_panic(
+        expected = "(msg_hash, msg_path) == curr_cert.SC2SC_message_tree_root/conditional_equals"
+    )]
+    fn if_invalid_msg_data(
+        mut rng: ThreadRng,
+        base_commitments: CommitmentPair,
+        #[values(true, false)] zk: bool,
+        #[case] action: TestChangeMsgAction,
+    ) {
+        let sc_id: FieldElement = rng.gen();
+
+        use TestChangeMsgAction::*;
+        let (msg_root, msg_hash, msg_path) = match (action, test_utils::messages(&mut rng, 1, 0)) {
+            (Root, (r, h, p)) => (r + FieldElement::one(), h, p),
+            (Hash, (r, h, p)) => (r, h + FieldElement::one(), p),
+            (Path, (r, h, p)) => (r, h, {
+                let mut raw = p.get_raw_path().clone();
+                raw[0].0 += FieldElement::one();
+                GingerMHTBinaryPath::new(raw)
+            }),
+        };
+
+        let (curr, next) = base_commitments;
+
+        let mut curr = curr
+            .with_certificate_msg_root(msg_root)
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (curr_cert, curr_cert_path, curr_sc_tx_commitment) =
+            curr.get_widthdrawal_certificate_info(0);
+
+        let mut next = next
+            .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (next_cert, next_cert_path, next_sc_tx_commitment) =
+            next.get_widthdrawal_certificate_info(0);
+
+        let sc2sc = Sc2Sc::new(
+            next_sc_tx_commitment,
+            curr_sc_tx_commitment,
+            msg_hash,
+            next_cert,
+            curr_cert,
+            next_cert_path,
+            curr_cert_path,
+            msg_path,
+        );
+
+        assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+    }
+
+    #[rstest]
+    #[serial]
+    #[should_panic(expected = "next_cert.previous_top_quality_hash == H(curr_cert_hash)")]
+    fn if_some_in_curr_cert_change(
+        mut rng: ThreadRng,
+        base_commitments: CommitmentPair,
+        #[values(true, false)] zk: bool,
+    ) {
+        let sc_id: FieldElement = rng.gen();
+        // Just one message in the root
+        let (msg_root, msg_hash, msg_path) = test_utils::messages(&mut rng, 1, 0);
+
+        let (curr, next) = base_commitments;
+
+        let mut curr = curr
+            .with_certificate_msg_root(msg_root)
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (mut curr_cert, curr_cert_path, curr_sc_tx_commitment) =
+            curr.get_widthdrawal_certificate_info(0);
+
+        let mut next = next
+            .with_max_quality_certificate_hash(curr_cert.hash().unwrap())
+            .generate_sc_data(None, &mut rng, sc_id);
+        let (next_cert, next_cert_path, next_sc_tx_commitment) =
+            next.get_widthdrawal_certificate_info(0);
+
+        curr_cert.btr_min_fee += 1;
+
+        let sc2sc = Sc2Sc::new(
+            next_sc_tx_commitment,
+            curr_sc_tx_commitment,
+            msg_hash,
+            next_cert,
+            curr_cert,
+            next_cert_path,
+            curr_cert_path,
+            msg_path,
+        );
+
+        assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
+    }
+}

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -179,14 +179,14 @@ fn happy_path(
     assert_circuit(sc2sc, if zk { Some(&mut rng) } else { None });
 }
 
-mod should_not_possible_to_add_a_circuit_if {
+mod should_not_possible_to_create_a_circuit_if {
     use super::*;
 
     #[test]
     #[should_panic(expected = "same custom fields")]
     fn certificates_have_not_the_same_numbers_of_custom_fields() {
-        let curr_cert = RandomWithdrawalCertificateDataBuilder::new(3).build();
-        let next_cert = RandomWithdrawalCertificateDataBuilder::new(4).build();
+        let curr_cert = RandomWithdrawalCertificateDataBuilder::new(MIN_CUSTOM_FIELDS).build();
+        let next_cert = RandomWithdrawalCertificateDataBuilder::new(MIN_CUSTOM_FIELDS + 1).build();
 
         Sc2Sc::new(
             FieldElement::zero(),
@@ -201,10 +201,10 @@ mod should_not_possible_to_add_a_circuit_if {
     }
 
     #[test]
-    #[should_panic(expected = "least 3 custom fields")]
-    fn certificates_have_less_than_3_custom_fields() {
-        let curr_cert = RandomWithdrawalCertificateDataBuilder::new(2).build();
-        let next_cert = RandomWithdrawalCertificateDataBuilder::new(2).build();
+    #[should_panic(expected = "need at least")]
+    fn certificates_have_less_than_minimum_custom_fields() {
+        let curr_cert = RandomWithdrawalCertificateDataBuilder::new(MIN_CUSTOM_FIELDS - 1).build();
+        let next_cert = RandomWithdrawalCertificateDataBuilder::new(MIN_CUSTOM_FIELDS - 1).build();
 
         Sc2Sc::new(
             FieldElement::zero(),
@@ -217,6 +217,15 @@ mod should_not_possible_to_add_a_circuit_if {
             GingerMHTBinaryPath::new(vec![(FieldElement::default(), false); MSG_MT_HEIGHT]),
         );
     }
+}
+
+#[rstest]
+#[case::minimum(MIN_CUSTOM_FIELDS)]
+#[case::lot_of(MIN_CUSTOM_FIELDS + 42)]
+#[should_panic(expected = "need at least")]
+#[case::should_fail_with_less_than_3(MIN_CUSTOM_FIELDS - 1)]
+fn setup_a_circuit_with_some_custom_fields(#[case] n_custom_fields: usize) {
+    Sc2Sc::get_instance_for_setup(n_custom_fields as u32);
 }
 
 mod should_fail {

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -32,7 +32,6 @@ impl ScCommitmentCertPath {
             .get_cert_leaves(&sc_id)
             .and_then(|certs| certs.iter().position(|h| h == &cert_hash))?;
         Self::new(
-            cmt.get_cert_commitment(&sc_id)?,
             cmt.get_fwt_commitment(&sc_id)?,
             cmt.get_bwtr_commitment(&sc_id)?,
             cmt.get_scc(&sc_id)?,
@@ -268,7 +267,6 @@ mod should_fail {
         ScTxCommitmentRoot,
         FTRootHash,
         BTRootHash,
-        WCertRoot,
         SSC,
         CertPath,
         ScCommitmentPath,
@@ -276,30 +274,15 @@ mod should_fail {
 
     #[rstest]
     #[serial]
-    #[should_panic(
-        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
-    )]
     #[case::sc_tx_commitment_root(TestChangeTxPathAction::ScTxCommitmentRoot)]
-    #[should_panic(expected = "Current epoch sc_tx_commitment_root recostruction")]
-    #[case::widthdrawal_certificate_root(TestChangeTxPathAction::WCertRoot)]
-    #[should_panic(
-        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
-    )]
     #[case::forward_transfert_root(TestChangeTxPathAction::FTRootHash)]
-    #[should_panic(
-        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
-    )]
     #[case::backward_transfert_root(TestChangeTxPathAction::BTRootHash)]
-    #[should_panic(
-        expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
-    )]
     #[case::start_side_chain(TestChangeTxPathAction::SSC)]
-    #[should_panic(expected = "Current epoch sc_tx_commitment_root recostruction")]
     #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
+    #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
     #[should_panic(
         expected = "(curr_sc_tx_commitment, curr_sc_tx_commitments_path) == curr_sc_tx_commitments_root"
     )]
-    #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
     fn if_invalid_current_sc_commitment_path(
         mut rng: ThreadRng,
         base_commitments: CommitmentPair,
@@ -328,9 +311,6 @@ mod should_fail {
         match action {
             ScTxCommitmentRoot => {
                 curr_sc_tx_commitment += FieldElement::one();
-            }
-            WCertRoot => {
-                curr_cert_path.cert_root += FieldElement::one();
             }
             FTRootHash => {
                 curr_cert_path.fwt_root += FieldElement::one();
@@ -369,30 +349,15 @@ mod should_fail {
 
     #[rstest]
     #[serial]
-    #[should_panic(
-        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
-    )]
     #[case::sc_tx_commitment_root(TestChangeTxPathAction::ScTxCommitmentRoot)]
-    #[should_panic(expected = "Next epoch sc_tx_commitment_root recostruction")]
-    #[case::widthdrawal_certificate_root(TestChangeTxPathAction::WCertRoot)]
-    #[should_panic(
-        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
-    )]
     #[case::forward_transfert_root(TestChangeTxPathAction::FTRootHash)]
-    #[should_panic(
-        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
-    )]
     #[case::backward_transfert_root(TestChangeTxPathAction::BTRootHash)]
-    #[should_panic(
-        expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
-    )]
     #[case::start_side_chain(TestChangeTxPathAction::SSC)]
-    #[should_panic(expected = "Next epoch sc_tx_commitment_root recostruction")]
     #[case::widthdrawal_certificate_path(TestChangeTxPathAction::CertPath)]
+    #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
     #[should_panic(
         expected = "(next_sc_tx_commitment, next_sc_tx_commitments_path) == next_sc_tx_commitments_root"
     )]
-    #[case::sidechain_commitment_path(TestChangeTxPathAction::ScCommitmentPath)]
     fn if_invalid_next_sc_commitment_path(
         mut rng: ThreadRng,
         base_commitments: CommitmentPair,
@@ -421,9 +386,6 @@ mod should_fail {
         match action {
             ScTxCommitmentRoot => {
                 next_sc_tx_commitment += FieldElement::one();
-            }
-            WCertRoot => {
-                next_cert_path.cert_root += FieldElement::one();
             }
             FTRootHash => {
                 next_cert_path.fwt_root += FieldElement::one();

--- a/demo-circuit/src/sc2sc/tests.rs
+++ b/demo-circuit/src/sc2sc/tests.rs
@@ -261,9 +261,9 @@ mod sc_commitment_cert_path {
             .generate_sc_data(None, &mut rng, sc_id);
 
         let (cert, mut path, root) = cmt.get_withdrawal_certificate_info(0);
-        let valid_mt = path.sc_commitment_path.clone();
+        let valid_mt = path.sc_comm_tree_path.clone();
 
-        let zero_mt = ScCommitmentCertPath::default().sc_commitment_path;
+        let zero_mt = ScCommitmentCertPath::default().sc_comm_tree_path;
 
         path.update_sc_commitment_path(zero_mt).unwrap();
 
@@ -430,10 +430,10 @@ mod should_fail {
                 curr_cert_path.fwt_root += FieldElement::one();
             }
             BTRootHash => {
-                curr_cert_path.bwt_root += FieldElement::one();
+                curr_cert_path.bt_root += FieldElement::one();
             }
             SSC => {
-                curr_cert_path.ssc += FieldElement::one();
+                curr_cert_path.ssc_tx += FieldElement::one();
             }
             CertPath => {
                 let mut raw = curr_cert_path.cert_path.get_raw_path().clone();
@@ -441,9 +441,9 @@ mod should_fail {
                 curr_cert_path.cert_path = GingerMHTBinaryPath::new(raw);
             }
             ScCommitmentPath => {
-                let mut raw = curr_cert_path.sc_commitment_path.get_raw_path().clone();
+                let mut raw = curr_cert_path.sc_comm_tree_path.get_raw_path().clone();
                 raw[0].0 += FieldElement::one();
-                curr_cert_path.sc_commitment_path = GingerMHTBinaryPath::new(raw);
+                curr_cert_path.sc_comm_tree_path = GingerMHTBinaryPath::new(raw);
             }
         }
 
@@ -503,10 +503,10 @@ mod should_fail {
                 next_cert_path.fwt_root += FieldElement::one();
             }
             BTRootHash => {
-                next_cert_path.bwt_root += FieldElement::one();
+                next_cert_path.bt_root += FieldElement::one();
             }
             SSC => {
-                next_cert_path.ssc += FieldElement::one();
+                next_cert_path.ssc_tx += FieldElement::one();
             }
             CertPath => {
                 let mut raw = curr_cert_path.cert_path.get_raw_path().clone();
@@ -514,9 +514,9 @@ mod should_fail {
                 next_cert_path.cert_path = GingerMHTBinaryPath::new(raw);
             }
             ScCommitmentPath => {
-                let mut raw = curr_cert_path.sc_commitment_path.get_raw_path().clone();
+                let mut raw = curr_cert_path.sc_comm_tree_path.get_raw_path().clone();
                 raw[0].0 += FieldElement::one();
-                next_cert_path.sc_commitment_path = GingerMHTBinaryPath::new(raw);
+                next_cert_path.sc_comm_tree_path = GingerMHTBinaryPath::new(raw);
             }
         }
 
@@ -595,7 +595,7 @@ mod should_fail {
 
     #[rstest]
     #[serial]
-    #[should_panic(expected = "next_cert.previous_top_quality_hash == H(curr_cert_hash)")]
+    #[should_panic(expected = "next_cert.previous_top_quality_hash == H(curr_cert)")]
     fn if_some_in_curr_cert_change(
         mut rng: impl Rng,
         base_commitments: CommitmentPair,

--- a/demo-circuit/src/test_utils.rs
+++ b/demo-circuit/src/test_utils.rs
@@ -1,0 +1,323 @@
+use std::convert::TryInto;
+
+use cctp_primitives::{
+    commitment_tree::CommitmentTree,
+    proving_system::init::{get_g1_committer_key, load_g1_committer_key},
+    type_mapping::{CommitterKeyG1, FieldElement, GingerMHT},
+};
+use primitives::FieldBasedMerkleTree;
+use rand::{rngs::ThreadRng, thread_rng, Rng};
+
+use crate::{
+    sc2sc::{
+        ScCommitmentCertPath, MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS, MSG_MT_HEIGHT,
+        MSG_ROOT_HASH_CUSTOM_FIELDS_POS,
+    },
+    GingerMHTBinaryPath, MAX_SEGMENT_SIZE, SUPPORTED_SEGMENT_SIZE, common::WithdrawalCertificateData,
+};
+
+pub(crate) fn init_g1_committer_key() -> CommitterKeyG1 {
+    let _ = load_g1_committer_key(MAX_SEGMENT_SIZE - 1);
+    let ck_g1 = get_g1_committer_key(Some(SUPPORTED_SEGMENT_SIZE - 1)).unwrap();
+    assert_eq!(ck_g1.comm_key.len(), SUPPORTED_SEGMENT_SIZE);
+    ck_g1
+}
+
+#[derive(Clone)]
+pub(crate) struct RandomWithdrawalCertificateDataBuilder {
+    ledger_id: Option<FieldElement>,
+    epoch_id: Option<u32>,
+    bt_root: Option<FieldElement>,
+    quality: Option<u64>,
+    mcb_sc_txs_com: Option<FieldElement>,
+    ft_min_amount: Option<u64>,
+    btr_min_fee: Option<u64>,
+    custom_fields: Vec<Option<FieldElement>>,
+}
+
+#[allow(unused)]
+impl RandomWithdrawalCertificateDataBuilder {
+    pub(crate) fn new(n_custom_field: usize) -> Self {
+        Self {
+            ledger_id: None,
+            epoch_id: None,
+            bt_root: None,
+            quality: None,
+            mcb_sc_txs_com: None,
+            ft_min_amount: None,
+            btr_min_fee: None,
+            custom_fields: vec![None; n_custom_field],
+        }
+    }
+
+    pub(crate) fn build(&self) -> WithdrawalCertificateData {
+        let mut rng = thread_rng();
+        self.build_with_rng(&mut rng)
+    }
+
+    pub(crate) fn build_with_rng(&self, rng: &mut ThreadRng) -> WithdrawalCertificateData {
+        let custom_fields = self.custom_fields.clone();
+        WithdrawalCertificateData {
+            ledger_id: self.ledger_id.unwrap_or_else(|| rng.gen()),
+            epoch_id: self.epoch_id.unwrap_or_else(|| rng.gen()),
+            bt_root: self.bt_root.unwrap_or_else(|| rng.gen()),
+            quality: self.quality.unwrap_or_else(|| rng.gen()),
+            mcb_sc_txs_com: self.mcb_sc_txs_com.unwrap_or_else(|| rng.gen()),
+            ft_min_amount: self.ft_min_amount.unwrap_or_else(|| rng.gen()),
+            btr_min_fee: self.btr_min_fee.unwrap_or_else(|| rng.gen()),
+            custom_fields: custom_fields
+                .iter()
+                .map(|v| v.unwrap_or_else(|| rng.gen()))
+                .collect(),
+        }
+    }
+
+    pub(crate) fn with_ledger_id(&mut self, v: FieldElement) -> &mut Self {
+        self.ledger_id = Some(v);
+        self
+    }
+
+    pub(crate) fn with_epoch_id(&mut self, v: u32) -> &mut Self {
+        self.epoch_id = Some(v);
+        self
+    }
+
+    pub(crate) fn with_bt_root(&mut self, v: FieldElement) -> &mut Self {
+        self.bt_root = Some(v);
+        self
+    }
+
+    pub(crate) fn with_quality(&mut self, v: u64) -> &mut Self {
+        self.quality = Some(v);
+        self
+    }
+
+    pub(crate) fn with_mcb_sc_txs_com(&mut self, v: FieldElement) -> &mut Self {
+        self.mcb_sc_txs_com = Some(v);
+        self
+    }
+
+    pub(crate) fn with_ft_min_amount(&mut self, v: u64) -> &mut Self {
+        self.ft_min_amount = Some(v);
+        self
+    }
+
+    pub(crate) fn with_btr_min_fee(&mut self, v: u64) -> &mut Self {
+        self.btr_min_fee = Some(v);
+        self
+    }
+
+    pub(crate) fn with_custom_fields(&mut self, v: Vec<FieldElement>) -> &mut Self {
+        self.custom_fields = v.into_iter().map(|field| Some(field)).collect();
+        self
+    }
+
+    pub(crate) fn with_custom_field(&mut self, pos: usize, v: FieldElement) -> &mut Self {
+        self.custom_fields
+            .resize((pos + 1).max(self.custom_fields.len()), None);
+        self.custom_fields[pos] = Some(v);
+        self
+    }
+}
+
+impl Default for RandomWithdrawalCertificateDataBuilder {
+    fn default() -> Self {
+        Self::new(1)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct CommitmentScBuilder {
+    epoch: u32,
+    n_forward_transfert: usize,
+    n_backward_transfert: usize,
+    n_withdrawal_certificates: usize,
+    certificate_builder: Option<RandomWithdrawalCertificateDataBuilder>,
+}
+
+impl CommitmentScBuilder {
+    pub(crate) fn with_epoch(mut self, epoch: u32) -> Self {
+        self.epoch = epoch;
+        self
+    }
+
+    pub(crate) fn with_n_forward_transfert(mut self, n_forward_transfert: usize) -> Self {
+        self.n_forward_transfert = n_forward_transfert;
+        self
+    }
+
+    pub(crate) fn with_n_backward_transfert(mut self, n_backward_transfert: usize) -> Self {
+        self.n_backward_transfert = n_backward_transfert;
+        self
+    }
+
+    pub(crate) fn with_n_withdrawal_certificates(
+        mut self,
+        n_withdrawal_certificates: usize,
+    ) -> Self {
+        self.n_withdrawal_certificates = n_withdrawal_certificates;
+        self
+    }
+
+    pub(crate) fn with_certificate_msg_root(mut self, msg_root: FieldElement) -> Self {
+        self.get_mut_certificates_builder()
+            .with_custom_field(MSG_ROOT_HASH_CUSTOM_FIELDS_POS, msg_root);
+        self
+    }
+
+    pub(crate) fn with_max_quality_certificate_hash(mut self, hash: FieldElement) -> Self {
+        self.get_mut_certificates_builder()
+            .with_custom_field(MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS, hash);
+        self
+    }
+
+    pub(crate) fn with_certificates_builder(
+        mut self,
+        builder: RandomWithdrawalCertificateDataBuilder,
+    ) -> Self {
+        self.certificate_builder = Some(builder);
+        self
+    }
+
+    pub(crate) fn generate_sc_data(
+        &self,
+        cmt: Option<CommitmentHelper>,
+        rng: &mut ThreadRng,
+        sc_id: FieldElement,
+    ) -> CommitmentHelper {
+        let mut cmt = cmt.unwrap_or_default();
+        let mut cert_builder = self.certificate_builder.clone().unwrap_or_default();
+        cert_builder.with_ledger_id(sc_id).with_epoch_id(self.epoch);
+
+        cmt.add_random_forward_transert_to_sc(rng, &sc_id, self.n_forward_transfert);
+        cmt.add_random_backward_transert_to_sc(rng, &sc_id, self.n_backward_transfert);
+        cmt.add_random_withdrawal_certificates_to_sc(
+            rng,
+            &sc_id,
+            cert_builder,
+            self.n_withdrawal_certificates,
+        );
+        cmt.set_random_start_sc(rng, &sc_id);
+
+        cmt
+    }
+
+    fn get_mut_certificates_builder(&mut self) -> &mut RandomWithdrawalCertificateDataBuilder {
+        if self.certificate_builder.is_none() {
+            self.certificate_builder = Some(RandomWithdrawalCertificateDataBuilder::default());
+        }
+        self.certificate_builder.as_mut().unwrap()
+    }
+}
+
+pub(crate) struct CommitmentHelper {
+    cmt: CommitmentTree,
+    certs: Vec<WithdrawalCertificateData>,
+}
+
+impl CommitmentHelper {
+    pub(crate) fn add_random_forward_transert_to_sc(
+        &mut self,
+        rng: &mut ThreadRng,
+        sc_id: &FieldElement,
+        n: usize,
+    ) {
+        (0..n).for_each(|_| {
+            self.cmt.add_bwtr_leaf(sc_id, &rng.gen());
+        });
+    }
+
+    pub(crate) fn add_random_backward_transert_to_sc(
+        &mut self,
+        rng: &mut ThreadRng,
+        sc_id: &FieldElement,
+        n: usize,
+    ) {
+        (0..n).for_each(|_| {
+            self.cmt.add_fwt_leaf(sc_id, &rng.gen());
+        });
+    }
+
+    pub(crate) fn add_random_withdrawal_certificates_to_sc(
+        &mut self,
+        rng: &mut ThreadRng,
+        sc_id: &FieldElement,
+        builder: RandomWithdrawalCertificateDataBuilder,
+        n: usize,
+    ) {
+        let mut certs: Vec<_> = (0..n).map(|_| builder.build_with_rng(rng)).collect();
+        certs.iter().for_each(|c| {
+            self.cmt.add_cert_leaf(&sc_id, &c.hash().unwrap());
+        });
+        self.certs.append(&mut certs);
+    }
+
+    pub(crate) fn get_widthdrawal_certificate_info(
+        &mut self,
+        pos: usize,
+    ) -> (
+        WithdrawalCertificateData,
+        ScCommitmentCertPath,
+        FieldElement,
+    ) {
+        let cert = self.get_withdrawal_certificate(pos).clone();
+        let path = self.get_certificate_path(&cert);
+        let sc_tx_commitment = self.get_commitment();
+        (cert, path, sc_tx_commitment)
+    }
+
+    pub(crate) fn get_withdrawal_certificate(&self, id: usize) -> &WithdrawalCertificateData {
+        &self.certs[id]
+    }
+
+    pub(crate) fn set_random_start_sc(&mut self, rng: &mut ThreadRng, sc_id: &FieldElement) {
+        self.cmt.set_scc(&sc_id, &rng.gen());
+    }
+
+    pub(crate) fn get_certificate_path(
+        &mut self,
+        cert: &WithdrawalCertificateData,
+    ) -> ScCommitmentCertPath {
+        let hash = cert.hash().unwrap();
+        ScCommitmentCertPath::from_commitment(&mut self.cmt, cert.ledger_id, hash)
+            .expect("Cannot extract path for certificate")
+    }
+
+    pub(crate) fn get_commitment(&mut self) -> FieldElement {
+        self.cmt
+            .get_commitment()
+            .expect("Cannot get sc_tx_commitment")
+    }
+}
+
+impl Default for CommitmentHelper {
+    fn default() -> Self {
+        Self {
+            cmt: CommitmentTree::create(),
+            certs: Default::default(),
+        }
+    }
+}
+
+/// Generate a messages tree with `n` leafs and return for the `pos`'s the root, msg hash
+/// and merkle path from leaf to root
+pub(crate) fn messages(
+    rng: &mut ThreadRng,
+    n: usize,
+    pos: usize,
+) -> (FieldElement, FieldElement, GingerMHTBinaryPath) {
+    let mut msg_tree = GingerMHT::init(MSG_MT_HEIGHT, 1 << MSG_MT_HEIGHT).unwrap();
+    (0..n).for_each(|_| {
+        msg_tree.append(rng.gen()).unwrap();
+    });
+    msg_tree.finalize_in_place().unwrap();
+    let msg_hash = msg_tree.get_leaves()[pos];
+    let msg_path = msg_tree
+        .get_merkle_path(pos)
+        .expect("Msg tree is not finalized yet");
+    (
+        msg_tree.root().expect("Massage tree is not finalizaed yet"),
+        msg_hash,
+        msg_path.try_into().expect("Should be a binary tree"),
+    )
+}

--- a/demo-circuit/src/test_utils.rs
+++ b/demo-circuit/src/test_utils.rs
@@ -24,6 +24,8 @@ pub(crate) fn init_g1_committer_key() -> CommitterKeyG1 {
     ck_g1
 }
 
+// TODO: Maybe this file could be moved in zendoo-cctp-lib.
+
 #[derive(Clone)]
 pub(crate) struct RandomWithdrawalCertificateDataBuilder {
     ledger_id: Option<FieldElement>,

--- a/demo-circuit/src/test_utils.rs
+++ b/demo-circuit/src/test_utils.rs
@@ -9,11 +9,9 @@ use primitives::FieldBasedMerkleTree;
 use rand::{rngs::ThreadRng, thread_rng, Rng};
 
 use crate::{
-    sc2sc::{
-        ScCommitmentCertPath, MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS, MSG_MT_HEIGHT,
-        MSG_ROOT_HASH_CUSTOM_FIELDS_POS,
-    },
-    GingerMHTBinaryPath, MAX_SEGMENT_SIZE, SUPPORTED_SEGMENT_SIZE, common::WithdrawalCertificateData,
+    common::{WithdrawalCertificateData, MSG_ROOT_HASH_CUSTOM_FIELDS_POS, MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS},
+    sc2sc::{ScCommitmentCertPath, MSG_MT_HEIGHT},
+    GingerMHTBinaryPath, MAX_SEGMENT_SIZE, SUPPORTED_SEGMENT_SIZE,
 };
 
 pub(crate) fn init_g1_committer_key() -> CommitterKeyG1 {

--- a/demo-circuit/src/test_utils.rs
+++ b/demo-circuit/src/test_utils.rs
@@ -132,8 +132,8 @@ impl Default for RandomWithdrawalCertificateDataBuilder {
 #[derive(Default)]
 pub(crate) struct CommitmentScBuilder {
     epoch: u32,
-    n_forward_transfert: usize,
-    n_backward_transfert: usize,
+    n_forward_transfer: usize,
+    n_backward_transfer: usize,
     n_withdrawal_certificates: usize,
     certificate_builder: Option<RandomWithdrawalCertificateDataBuilder>,
 }
@@ -144,13 +144,13 @@ impl CommitmentScBuilder {
         self
     }
 
-    pub(crate) fn with_n_forward_transfert(mut self, n_forward_transfert: usize) -> Self {
-        self.n_forward_transfert = n_forward_transfert;
+    pub(crate) fn with_n_forward_transfer(mut self, n_forward_transfer: usize) -> Self {
+        self.n_forward_transfer = n_forward_transfer;
         self
     }
 
-    pub(crate) fn with_n_backward_transfert(mut self, n_backward_transfert: usize) -> Self {
-        self.n_backward_transfert = n_backward_transfert;
+    pub(crate) fn with_n_backward_transfer(mut self, n_backward_transfer: usize) -> Self {
+        self.n_backward_transfer = n_backward_transfer;
         self
     }
 
@@ -192,8 +192,8 @@ impl CommitmentScBuilder {
         let mut cert_builder = self.certificate_builder.clone().unwrap_or_default();
         cert_builder.with_ledger_id(sc_id).with_epoch_id(self.epoch);
 
-        cmt.add_random_forward_transert_to_sc(rng, &sc_id, self.n_forward_transfert);
-        cmt.add_random_backward_transert_to_sc(rng, &sc_id, self.n_backward_transfert);
+        cmt.add_random_forward_transert_to_sc(rng, &sc_id, self.n_forward_transfer);
+        cmt.add_random_backward_transert_to_sc(rng, &sc_id, self.n_backward_transfer);
         cmt.add_random_withdrawal_certificates_to_sc(
             rng,
             &sc_id,
@@ -255,7 +255,7 @@ impl CommitmentHelper {
         self.certs.append(&mut certs);
     }
 
-    pub(crate) fn get_widthdrawal_certificate_info(
+    pub(crate) fn get_withdrawal_certificate_info(
         &mut self,
         pos: usize,
     ) -> (

--- a/demo-circuit/src/test_utils.rs
+++ b/demo-circuit/src/test_utils.rs
@@ -194,8 +194,8 @@ impl CommitmentScBuilder {
         let mut cert_builder = self.certificate_builder.clone().unwrap_or_default();
         cert_builder.with_ledger_id(sc_id).with_epoch_id(self.epoch);
 
-        cmt.add_random_forward_transert_to_sc(rng, &sc_id, self.n_forward_transfer);
-        cmt.add_random_backward_transert_to_sc(rng, &sc_id, self.n_backward_transfer);
+        cmt.add_random_forward_transfer_to_sc(rng, &sc_id, self.n_forward_transfer);
+        cmt.add_random_backward_transfer_to_sc(rng, &sc_id, self.n_backward_transfer);
         cmt.add_random_withdrawal_certificates_to_sc(
             rng,
             &sc_id,
@@ -221,7 +221,7 @@ pub(crate) struct CommitmentHelper {
 }
 
 impl CommitmentHelper {
-    pub(crate) fn add_random_forward_transert_to_sc(
+    pub(crate) fn add_random_forward_transfer_to_sc(
         &mut self,
         rng: &mut (impl Rng + ?Sized),
         sc_id: &FieldElement,
@@ -232,7 +232,7 @@ impl CommitmentHelper {
         });
     }
 
-    pub(crate) fn add_random_backward_transert_to_sc(
+    pub(crate) fn add_random_backward_transfer_to_sc(
         &mut self,
         rng: &mut (impl Rng + ?Sized),
         sc_id: &FieldElement,

--- a/jni/pom.xml
+++ b/jni/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.horizen</groupId>
   <artifactId>zendoo-sc-cryptolib</artifactId>
-  <version>0.7.0</version>
+  <version>0.8.0-SNAPSHOT</version>
   <inceptionYear>2020</inceptionYear>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>

--- a/jni/src/main/java/com/horizen/certnative/NaiveThresholdSignatureWKeyRotation.java
+++ b/jni/src/main/java/com/horizen/certnative/NaiveThresholdSignatureWKeyRotation.java
@@ -4,6 +4,7 @@ import com.horizen.librustsidechains.Library;
 import com.horizen.librustsidechains.FieldElement;
 import com.horizen.schnorrnative.SchnorrSignature;
 import com.horizen.schnorrnative.ValidatorKeysUpdatesList;
+import com.horizen.schnorrnative.SchnorrPublicKey;
 import com.horizen.provingsystemnative.ProvingSystemType;
 
 import java.util.List;

--- a/jni/src/main/java/com/horizen/certnative/NaiveThresholdSignatureWKeyRotation.java
+++ b/jni/src/main/java/com/horizen/certnative/NaiveThresholdSignatureWKeyRotation.java
@@ -2,7 +2,6 @@ package com.horizen.certnative;
 
 import com.horizen.librustsidechains.Library;
 import com.horizen.librustsidechains.FieldElement;
-import com.horizen.schnorrnative.SchnorrPublicKey;
 import com.horizen.schnorrnative.SchnorrSignature;
 import com.horizen.schnorrnative.ValidatorKeysUpdatesList;
 import com.horizen.provingsystemnative.ProvingSystemType;

--- a/jni/src/main/java/com/horizen/commitmenttreenative/CommitmentTree.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/CommitmentTree.java
@@ -39,7 +39,7 @@ public class CommitmentTree implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeCommitmentTree();
     }
 
@@ -239,5 +239,22 @@ public class CommitmentTree implements AutoCloseable {
 
     public Optional<MerklePath> getCertMerklePath(byte[] scId, int leafIndex) {
         return nativeGetCertMerklePath(scId, leafIndex);
+    }
+
+    private native Optional<ScCommitmentCertPath> nativeGetScCommitmentCertPath(byte[] scId, byte[] certLeafHash);
+
+    /**
+     * Return the path from the certificate hash to the root of sidechain tx commitments root. That
+     * is not a simple merkle path but provides all the info that we need to generate the root from 
+     * the certificate.
+     * 
+     * @param scId              - The sidechain id
+     * @param certLeafHash      - The certificate hash
+     * @return                  - A ScCommitmentCertPath to build the sidechain tx commitments root
+     *                              from the ceritificate hash leaf (if the certificate hash is a
+     *                              leaf of the certificates tree).
+     */
+    public Optional<ScCommitmentCertPath> getScCommitmentCertPath(byte[] scId, byte[] certLeafHash) {
+        return nativeGetScCommitmentCertPath(scId, certLeafHash);
     }
 }

--- a/jni/src/main/java/com/horizen/commitmenttreenative/ScAbsenceProof.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/ScAbsenceProof.java
@@ -42,7 +42,7 @@ public class ScAbsenceProof implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeScAbsenceProof();
     }
 }

--- a/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
@@ -1,0 +1,90 @@
+package com.horizen.commitmenttreenative;
+
+import java.util.Optional;
+
+import com.horizen.librustsidechains.FieldElement;
+import com.horizen.librustsidechains.Library;
+
+/*
+ * This class represent a path from the certificate to the root of side chain
+ * tx commitments root. That is not a simple merkle path because we need use a
+ * merkle path to find the root of the merkle tree of the cerificates, hash it 
+ * with the sidechain id and two other roots (forward transfert and backward 
+ * transfert); Finally use this hash to compute the final root.
+ */
+public class ScCommitmentCertPath implements AutoCloseable {
+
+    private long scCommitmentCertPathPointer;
+
+    static {
+        Library.load();
+    }
+
+    private native Optional<FieldElement> nativeApply(FieldElement scId, FieldElement hash);
+
+    private ScCommitmentCertPath(long scCommitCertPathPointer) {
+        if (scCommitCertPathPointer == 0) {
+            throw new IllegalArgumentException("scCommitmentPathPointer must be not null.");
+        }
+        this.scCommitmentCertPathPointer = scCommitCertPathPointer;
+    }
+
+    /*
+     * Rebuild the root of a sidechain commitment tree `scId` for certificate
+     * `hash`.
+     */
+    public Optional<FieldElement> apply(FieldElement scId, FieldElement hash) {
+        return nativeApply(scId, hash);
+    }
+
+    private native boolean nativeVerify(FieldElement scTxCommitmentRoot, FieldElement scId, FieldElement hash);
+
+    /*
+     * Verify the Path for certificate `hash` given the `root` of a sidechain
+     * commitment tree `scId`.
+     */
+    public boolean verify(FieldElement scTxCommitmentRoot, FieldElement scId, FieldElement hash) {
+        check();
+        return nativeVerify(scTxCommitmentRoot, scId, hash);
+    }
+
+    private native void nativeFreeScCommitmentCertPath(long scCommitCertPathPointer);
+
+    // Take care: not thread safe. If the istance is not shared is not an issue.
+    public void freeScCommitmentCertPath() {
+        if (scCommitmentCertPathPointer != 0) {
+            nativeFreeScCommitmentCertPath(this.scCommitmentCertPathPointer);
+            scCommitmentCertPathPointer = 0;
+        }
+    }
+
+    private native byte[] nativeSerialize();
+
+    public byte[] serialize() {
+        check();
+
+        return nativeSerialize();
+    }
+
+    private static native ScCommitmentCertPath nativeDeserialize(byte[] scCommitmnetCertPathBytes,
+            boolean semanticChecks);
+
+    public static ScCommitmentCertPath deserialize(byte[] scCommitmnetCertPathBytes, boolean semanticChecks) {
+        return nativeDeserialize(scCommitmnetCertPathBytes, semanticChecks);
+    }
+
+    public static ScCommitmentCertPath deserialize(byte[] scCommitmnetCertPathBytes) {
+        return nativeDeserialize(scCommitmnetCertPathBytes, true);
+    }
+
+    @Override
+    public void close() {
+        freeScCommitmentCertPath();
+    }
+
+    private void check() {
+        if (scCommitmentCertPathPointer == 0) {
+            throw new IllegalStateException("Field element was freed.");
+        }
+    }
+}

--- a/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import com.horizen.librustsidechains.FieldElement;
 import com.horizen.librustsidechains.Library;
+import com.horizen.merkletreenative.MerklePath;
 
 /*
  * This class represent a path from the certificate to the root of side chain
@@ -86,5 +87,17 @@ public class ScCommitmentCertPath implements AutoCloseable {
         if (scCommitmentCertPathPointer == 0) {
             throw new IllegalStateException("Field element was freed.");
         }
+    }
+
+    private native boolean nativeUpdateScCommitmentPath(MerklePath correctScPath) throws IllegalArgumentException;
+
+    /**
+     * Update the path from the sidechain tx root to the commitment root
+     * 
+     * @param path The new merkle path from the sidechain root to the commitment root
+     * @throws IllegalArgumentException if the given merkle path is not valid (wrong length)
+     */
+    public void updateScCommitmentPath(MerklePath path) throws IllegalArgumentException{
+        nativeUpdateScCommitmentPath(path);
     }
 }

--- a/jni/src/main/java/com/horizen/commitmenttreenative/ScExistenceProof.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/ScExistenceProof.java
@@ -42,7 +42,7 @@ public class ScExistenceProof implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeScExistenceProof();
     }
 }

--- a/jni/src/main/java/com/horizen/cswnative/CswFtProverData.java
+++ b/jni/src/main/java/com/horizen/cswnative/CswFtProverData.java
@@ -86,7 +86,7 @@ public class CswFtProverData implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.mcbScTxsComStart.close();
         this.merklePathToScHash.close();
         this.ftTreePath.close();

--- a/jni/src/main/java/com/horizen/cswnative/CswSysData.java
+++ b/jni/src/main/java/com/horizen/cswnative/CswSysData.java
@@ -59,7 +59,7 @@ public class CswSysData implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (this.constant.isPresent())
             this.constant.get().close();
 

--- a/jni/src/main/java/com/horizen/cswnative/CswUtxoProverData.java
+++ b/jni/src/main/java/com/horizen/cswnative/CswUtxoProverData.java
@@ -38,7 +38,7 @@ public class CswUtxoProverData implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.mstPathToOutput.close();
     }
 }

--- a/jni/src/main/java/com/horizen/librustsidechains/Constants.java
+++ b/jni/src/main/java/com/horizen/librustsidechains/Constants.java
@@ -22,6 +22,10 @@ public final class Constants {
     private static int VRF_PK_LENGTH;
     private static int VRF_SK_LENGTH;
     private static int VRF_PROOF_LENGTH;
+    private static int MSG_ROOT_HASH_CUSTOM_FIELDS_POS;
+    private static int MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS;
+    private static int MIN_CUSTOM_FIELDS;
+    private static int MSG_MT_HEIGHT;
 
     private static native void nativeInitializeAllConstants();
 
@@ -88,5 +92,21 @@ public final class Constants {
 
     public static int VRF_PROOF_LENGTH() {
         return VRF_PROOF_LENGTH;
+    }
+
+    public static int MSG_ROOT_HASH_CUSTOM_FIELDS_POS() {
+        return MSG_ROOT_HASH_CUSTOM_FIELDS_POS;
+    }
+
+    public static int MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS() {
+        return MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS;
+    }
+
+    public static int MIN_CUSTOM_FIELDS() {
+        return MIN_CUSTOM_FIELDS;
+    }
+
+    public static int MSG_MT_HEIGHT() {
+        return MSG_MT_HEIGHT;
     }
 }

--- a/jni/src/main/java/com/horizen/merkletreenative/InMemoryAppendOnlyMerkleTree.java
+++ b/jni/src/main/java/com/horizen/merkletreenative/InMemoryAppendOnlyMerkleTree.java
@@ -113,7 +113,7 @@ public class InMemoryAppendOnlyMerkleTree implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeInMemoryOptimizedMerkleTree();
     }
 }

--- a/jni/src/main/java/com/horizen/merkletreenative/InMemorySparseMerkleTree.java
+++ b/jni/src/main/java/com/horizen/merkletreenative/InMemorySparseMerkleTree.java
@@ -135,7 +135,7 @@ public class InMemorySparseMerkleTree implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeInMemorySparseMerkleTree();
     }
 }

--- a/jni/src/main/java/com/horizen/merkletreenative/MerklePath.java
+++ b/jni/src/main/java/com/horizen/merkletreenative/MerklePath.java
@@ -155,7 +155,7 @@ public class MerklePath implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeMerklePath();
     }
 }

--- a/jni/src/main/java/com/horizen/poseidonnative/PoseidonHash.java
+++ b/jni/src/main/java/com/horizen/poseidonnative/PoseidonHash.java
@@ -132,7 +132,7 @@ public class PoseidonHash implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freePoseidonHash();
     }
 }

--- a/jni/src/main/java/com/horizen/sc2scnative/Sc2Sc.java
+++ b/jni/src/main/java/com/horizen/sc2scnative/Sc2Sc.java
@@ -309,9 +309,9 @@ public class Sc2Sc {
          * check the proving key and assume that proving key and proof are compressed.
          * This varian take arrays of bytes instead of FieldElement.
          * 
-         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root (public)
-         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for (public)
-         * @param msgHash                    - Message hash (public)
+         * @param nextScTxCommitmentsRootB    - Next epoch sc tx root (public)
+         * @param currentScTxCommitmentsRootB - Current epoch sc tx root for (public)
+         * @param msgHashB                    - Message hash (public)
          * @param nextWithdrawalCertificate  - Next epoch Withdrowal Certificate
          *                                   (witness)
          * @param currWithdrawalCertificate  - Current epoch Withdrowal Certificate

--- a/jni/src/main/java/com/horizen/sc2scnative/Sc2Sc.java
+++ b/jni/src/main/java/com/horizen/sc2scnative/Sc2Sc.java
@@ -168,9 +168,9 @@ public class Sc2Sc {
          * arrays
          * of bytes instead of FieldElement.
          * 
-         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root
-         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for
-         * @param msgHash                    - Message hash
+         * @param nextScTxCommitmentsRootB    - Next epoch sc tx root
+         * @param currentScTxCommitmentsRootB - Current epoch sc tx root for
+         * @param msgHashB                    - Message hash
          * @param proof                      - The serialized proof (see createProof
          *                                   methods)
          * @param vkPath                     - Verification Key file path

--- a/jni/src/main/java/com/horizen/sc2scnative/Sc2Sc.java
+++ b/jni/src/main/java/com/horizen/sc2scnative/Sc2Sc.java
@@ -1,0 +1,360 @@
+package com.horizen.sc2scnative;
+
+import java.util.Optional;
+
+import com.horizen.certnative.WithdrawalCertificate;
+import com.horizen.commitmenttreenative.ScCommitmentCertPath;
+import com.horizen.librustsidechains.FieldElement;
+import com.horizen.librustsidechains.Library;
+import com.horizen.merkletreenative.MerklePath;
+import com.horizen.provingsystemnative.ProvingSystemType;
+
+public class Sc2Sc {
+
+        static {
+                Library.load();
+        }
+
+        private static native boolean nativeSetup(
+                        ProvingSystemType psType,
+                        int numCustomFields,
+                        Optional<Integer> segmentSize,
+                        String provingKeyPath,
+                        String verificationKeyPath,
+                        boolean zk,
+                        int maxProofPlusVkSize,
+                        boolean compressPk,
+                        boolean compressVk) throws Exception;
+
+        /**
+         * Generate (provingKey, verificationKey) pair for this circuit.
+         * 
+         * @param psType
+         *                            - proving system to be used
+         * @param numCustomFields
+         *                            - exact number of custom fields the circuit must
+         *                            support
+         * @param segmentSize         - the segment size to be used to generate (pk,
+         *                            vk). Must be smaller equal than
+         *                            the segment size passed to the
+         *                            ProvingSystem.generateDLogKeys() method.
+         *                            If not specified, it will default to the same size
+         *                            as the one passed to
+         *                            ProvingSystem.generateDLogKeys() method.
+         * @param provingKeyPath      - file path to which saving the proving key
+         * @param verificationKeyPath - file path to which saving the verification key
+         * @param zk                  - used to estimate the proof and vk size, tells if
+         *                            the proof will be created using zk or not
+         * @param maxProofPlusVkSize  - maximum allowed size for proof + vk
+         * @param compressPk          - if the proving key must be saved to
+         *                            provingKeyPath in compressed form
+         * @param compressVk          - if the verification key must be saved to
+         *                            verificationKeyPath in compressed form
+         * @return true if (pk, vk) generation and saving to file was successfull
+         * @throws Exception if (pk, vk) generation or saving to file fails
+         */
+        public static boolean setup(
+                        ProvingSystemType psType,
+                        int numCustomFields,
+                        Optional<Integer> segmentSize,
+                        String provingKeyPath,
+                        String verificationKeyPath,
+                        boolean zk,
+                        int maxProofPlusVkSize,
+                        boolean compressPk,
+                        boolean compressVk) throws Exception {
+                return nativeSetup(
+                                psType, numCustomFields, segmentSize, provingKeyPath,
+                                verificationKeyPath, zk, maxProofPlusVkSize, compressPk, compressVk);
+
+        }
+
+        /**
+         * Generate a compressed (provingKey, verificationKey) pair for this circuit.
+         * 
+         * @param psType
+         *                            - proving system to be used
+         * @param numCustomFields
+         *                            - exact number of custom fields the circuit must
+         *                            support
+         * @param segmentSize         - the segment size to be used to generate (pk,
+         *                            vk). Must be smaller equal than
+         *                            the segment size passed to the
+         *                            ProvingSystem.generateDLogKeys() method.
+         *                            If not specified, it will default to the same size
+         *                            as the one passed to
+         *                            ProvingSystem.generateDLogKeys() method.
+         * @param provingKeyPath      - file path to which saving the proving key
+         * @param verificationKeyPath - file path to which saving the verification key
+         * @param zk                  - used to estimate the proof and vk size, tells if
+         *                            the proof will be created using zk or not
+         * @param maxProofPlusVkSize  - maximum allowed size for proof + vk
+         * @return true if (pk, vk) generation and saving to file was successfull
+         * @throws Exception if (pk, vk) generation or saving to file fails
+         */
+        public static boolean setup(
+                        ProvingSystemType psType,
+                        int numCustomFields,
+                        Optional<Integer> segmentSize,
+                        String provingKeyPath,
+                        String verificationKeyPath,
+                        boolean zk,
+                        int maxProofPlusVkSize) throws Exception {
+                return setup(psType, numCustomFields, segmentSize, provingKeyPath,
+                                verificationKeyPath, zk, maxProofPlusVkSize, true, true);
+
+        }
+
+        private static native boolean nativeVerifyProof(
+                        FieldElement nextScTxCommitmentRoot,
+                        FieldElement currentScTxCommitmentRoot,
+                        FieldElement msgHash,
+                        byte[] proof,
+                        String vKPath,
+                        boolean checkProof,
+                        boolean compressedProof,
+                        boolean checkVk,
+                        boolean compressedVk);
+
+        /**
+         * Verify a sidechain to sidechain redeemed message proof.
+         * 
+         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root
+         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for
+         * @param msgHash                    - Message hash
+         * @param proof                      - The serialized proof (see createProof
+         *                                   methods)
+         * @param vkPath                     - Verification Key file path
+         * @param checkProof                 - Do or not the proof sematic check
+         * @param compressedProof            - Indicate if the proof is compressed or
+         *                                   not
+         * @param checkVk                    - Check or not check the verification key
+         * @param compressedVk               - Indicate if the verification key is
+         *                                   compressed or not
+         * @return True if the the proof can be verified with the given public input and
+         *         false otherwise.
+         */
+        public static boolean verifyProof(FieldElement nextScTxCommitmentsRoot, FieldElement currentScTxCommitmentsRoot,
+                        FieldElement msgHash, byte[] proof, String vkPath,
+                        boolean checkProof, boolean compressedProof, boolean checkVk, boolean compressedVk) {
+                return nativeVerifyProof(nextScTxCommitmentsRoot, currentScTxCommitmentsRoot, msgHash, proof,
+                                vkPath, checkProof, compressedProof, checkVk, compressedVk);
+        }
+
+        /**
+         * Verify a sidechain to sidechain redeemed message proof. In this case we
+         * assume
+         * that proof and the key are compressed and we check both.
+         * 
+         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root
+         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for
+         * @param msgHash                    - Message hash
+         * @param proof                      - The serialized proof (see createProof
+         *                                   methods)
+         * @param vkPath                     - Verification Key file path
+         * @return True if the the proof can be verified with the given public input and
+         *         false otherwise.
+         */
+        public static boolean verifyProof(FieldElement nextScTxCommitmentsRoot, FieldElement currentScTxCommitmentsRoot,
+                        FieldElement msgHash, byte[] proof, String vkPath) {
+                return verifyProof(nextScTxCommitmentsRoot, currentScTxCommitmentsRoot, msgHash,
+                                proof, vkPath, true, true, true, true);
+        }
+
+        /**
+         * Verify a sidechain to sidechain redeemed message proof. In this case we
+         * assume
+         * that proof and the key are compressed and we check both. This varian take
+         * arrays
+         * of bytes instead of FieldElement.
+         * 
+         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root
+         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for
+         * @param msgHash                    - Message hash
+         * @param proof                      - The serialized proof (see createProof
+         *                                   methods)
+         * @param vkPath                     - Verification Key file path
+         * @return True if the the proof can be verified with the given public input and
+         *         false otherwise.
+         */
+        public static boolean verifyProof(byte[] nextScTxCommitmentsRootB, byte[] currentScTxCommitmentsRootB,
+                        byte[] msgHashB,
+                        byte[] proof, String vkPath) {
+                try (FieldElement nextScTxCommitmentsRoot = FieldElement.deserialize(nextScTxCommitmentsRootB);
+                                FieldElement currentScTxCommitmentsRoot = FieldElement
+                                                .deserialize(currentScTxCommitmentsRootB);
+                                FieldElement msgHash = FieldElement.deserialize(msgHashB);) {
+                        return verifyProof(nextScTxCommitmentsRoot, currentScTxCommitmentsRoot, msgHash, proof, vkPath);
+                }
+        }
+
+        private static native byte[] nativeCreateProof(
+                        FieldElement nextScTxCommitmentsRoot,
+                        FieldElement currentScTxCommitmentsRoot,
+                        FieldElement msgHash,
+                        WithdrawalCertificate nextWithdrawalCertificate,
+                        WithdrawalCertificate currWithdrawalCertificate,
+                        ScCommitmentCertPath nextPath,
+                        ScCommitmentCertPath currentPath,
+                        MerklePath msgPath,
+                        Optional<Integer> segmentSize,
+                        String pkPath,
+                        boolean checkProvingKey,
+                        boolean zk,
+                        boolean compressedPk,
+                        boolean compressProof);
+
+        /**
+         * Create a proof for Side to Sidechain redeemed message
+         * 
+         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root (public)
+         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for (public)
+         * @param msgHash                    - Message hash (public)
+         * @param nextWithdrawalCertificate  - Next epoch Withdrowal Certificate
+         *                                   (witness)
+         * @param currWithdrawalCertificate  - Current epoch Withdrowal Certificate
+         *                                   (witness)
+         * @param nextPath                   - Next epoch certificate path (witness)
+         * @param currentPath                - Current epoch certificate path (witness)
+         * @param msgPath                    - Merkle tree message path (witness)
+         * @param segmentSize                - The segment size: SHOULD BE THE SAME USED
+         *                                   TO GENERATE THE PROVING KEY FILE
+         * @param pkPath                     - Proving Key file path
+         * @param checkProvingKey            - Check or not the proving key
+         * @param zk                         - Use zero knowledge or not
+         * @param compressedPk               - Indicate if the proving key is compressed
+         *                                   or not
+         * @param compressProof              - The proof will be compressed or not
+         * @return A Sidechain to sidechain serialized proof.
+         */
+        public static byte[] createProof(
+                        FieldElement nextScTxCommitmentsRoot,
+                        FieldElement currentScTxCommitmentsRoot,
+                        FieldElement msgHash,
+                        WithdrawalCertificate nextWithdrawalCertificate,
+                        WithdrawalCertificate currWithdrawalCertificate,
+                        ScCommitmentCertPath nextPath, ScCommitmentCertPath currentPath, MerklePath msgPath,
+                        Optional<Integer> segmentSize,
+                        String pkPath,
+                        boolean checkProvingKey,
+                        boolean zk,
+                        boolean compressedPk,
+                        boolean compressProof) {
+                return nativeCreateProof(
+                                nextScTxCommitmentsRoot,
+                                currentScTxCommitmentsRoot,
+                                msgHash,
+                                nextWithdrawalCertificate,
+                                currWithdrawalCertificate,
+                                nextPath,
+                                currentPath,
+                                msgPath,
+                                segmentSize,
+                                pkPath,
+                                checkProvingKey,
+                                zk,
+                                compressedPk,
+                                compressProof);
+        }
+
+        /**
+         * Create a proof for Side to Sidechain redeemed message. In this case it will
+         * check the proving key and assume that proving key and proof are compressed.
+         * 
+         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root (public)
+         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for (public)
+         * @param msgHash                    - Message hash (public)
+         * @param nextWithdrawalCertificate  - Next epoch Withdrowal Certificate
+         *                                   (witness)
+         * @param currWithdrawalCertificate  - Current epoch Withdrowal Certificate
+         *                                   (witness)
+         * @param nextPath                   - Next epoch certificate path (witness)
+         * @param currentPath                - Current epoch certificate path (witness)
+         * @param msgPath                    - Merkle tree message path (witness)
+         * @param segmentSize                - The segment size: SHOULD BE THE SAME USED
+         *                                   TO GENERATE THE PROVING KEY FILE
+         * @param pkPath                     - Proving Key file path
+         * @param zk                         - Use zero knowledge or not
+         * @return A Sidechain to sidechain serialized proof.
+         */
+        public static byte[] createProof(
+                        FieldElement nextScTxCommitmentsRoot,
+                        FieldElement currentScTxCommitmentsRoot,
+                        FieldElement msgHash,
+                        WithdrawalCertificate nextWithdrawalCertificate,
+                        WithdrawalCertificate currWithdrawalCertificate,
+                        ScCommitmentCertPath nextPath, ScCommitmentCertPath currentPath, MerklePath msgPath,
+                        Optional<Integer> segmentSize,
+                        String pkPath,
+                        boolean zk) {
+                return createProof(
+                                nextScTxCommitmentsRoot,
+                                currentScTxCommitmentsRoot,
+                                msgHash,
+                                nextWithdrawalCertificate,
+                                currWithdrawalCertificate,
+                                nextPath,
+                                currentPath,
+                                msgPath,
+                                segmentSize,
+                                pkPath,
+                                true,
+                                zk,
+                                true,
+                                true);
+        }
+
+        /**
+         * Create a proof for Side to Sidechain redeemed message. In this case it will
+         * check the proving key and assume that proving key and proof are compressed.
+         * This varian take arrays of bytes instead of FieldElement.
+         * 
+         * @param nextScTxCommitmentsRoot    - Next epoch sc tx root (public)
+         * @param currentScTxCommitmentsRoot - Current epoch sc tx root for (public)
+         * @param msgHash                    - Message hash (public)
+         * @param nextWithdrawalCertificate  - Next epoch Withdrowal Certificate
+         *                                   (witness)
+         * @param currWithdrawalCertificate  - Current epoch Withdrowal Certificate
+         *                                   (witness)
+         * @param nextPath                   - Next epoch certificate path (witness)
+         * @param currentPath                - Current epoch certificate path (witness)
+         * @param msgPath                    - Merkle tree message path (witness)
+         * @param segmentSize                - The segment size: SHOULD BE THE SAME USED
+         *                                   TO GENERATE THE PROVING KEY FILE
+         * @param pkPath                     - Proving Key file path
+         * @param zk                         - Use zero knowledge or not
+         * @return A Sidechain to sidechain serialized proof.
+         */
+        public static byte[] createProof(byte[] nextScTxCommitmentsRootB, byte[] currentScTxCommitmentsRootB,
+                        byte[] msgHashB,
+                        WithdrawalCertificate nextWithdrawalCertificate,
+                        WithdrawalCertificate currWithdrawalCertificate,
+                        ScCommitmentCertPath nextPath, ScCommitmentCertPath currentPath, MerklePath msgPath,
+                        String pkPath,
+                        Optional<Integer> segmentSize,
+                        boolean zk) {
+                // I know that multiple JNI call generate lot of overhead but I choose to do it
+                // because:
+                // - I prefer to call a native method that is type safe
+                // - I would provide to the end user also a method that not use FieldElement
+                // type and use almost as possible java type and not wraps of native ones.
+                try (FieldElement nextScTxCommitmentsRoot = FieldElement.deserialize(nextScTxCommitmentsRootB);
+                                FieldElement currentScTxCommitmentsRoot = FieldElement
+                                                .deserialize(currentScTxCommitmentsRootB);
+                                FieldElement msgHash = FieldElement.deserialize(msgHashB);) {
+                        return createProof(
+                                        nextScTxCommitmentsRoot,
+                                        currentScTxCommitmentsRoot,
+                                        msgHash,
+                                        nextWithdrawalCertificate,
+                                        currWithdrawalCertificate,
+                                        nextPath,
+                                        currentPath,
+                                        msgPath,
+                                        segmentSize,
+                                        pkPath,
+                                        zk);
+                }
+        }
+
+}

--- a/jni/src/main/java/com/horizen/schnorrnative/SchnorrKeyPair.java
+++ b/jni/src/main/java/com/horizen/schnorrnative/SchnorrKeyPair.java
@@ -54,7 +54,7 @@ public class SchnorrKeyPair implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.publicKey.close();
         this.secretKey.close();
     }

--- a/jni/src/main/java/com/horizen/schnorrnative/SchnorrPublicKey.java
+++ b/jni/src/main/java/com/horizen/schnorrnative/SchnorrPublicKey.java
@@ -83,7 +83,7 @@ public class SchnorrPublicKey implements AutoCloseable
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     freePublicKey();
   }
 }

--- a/jni/src/main/java/com/horizen/schnorrnative/SchnorrSecretKey.java
+++ b/jni/src/main/java/com/horizen/schnorrnative/SchnorrSecretKey.java
@@ -55,7 +55,7 @@ public class SchnorrSecretKey implements AutoCloseable
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeSecretKey();
     }
 }

--- a/jni/src/main/java/com/horizen/schnorrnative/SchnorrSignature.java
+++ b/jni/src/main/java/com/horizen/schnorrnative/SchnorrSignature.java
@@ -61,7 +61,7 @@ public class SchnorrSignature implements AutoCloseable
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     freeSignature();
   }
 }

--- a/jni/src/main/java/com/horizen/schnorrnative/ValidatorKeysUpdatesList.java
+++ b/jni/src/main/java/com/horizen/schnorrnative/ValidatorKeysUpdatesList.java
@@ -1,6 +1,5 @@
 package com.horizen.schnorrnative;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.horizen.librustsidechains.Library;
@@ -182,7 +181,7 @@ public class ValidatorKeysUpdatesList implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         for (SchnorrPublicKey pk : signingKeys)
             pk.close();
         for (SchnorrPublicKey pk : masterKeys)

--- a/jni/src/main/java/com/horizen/vrfnative/VRFKeyPair.java
+++ b/jni/src/main/java/com/horizen/vrfnative/VRFKeyPair.java
@@ -55,7 +55,7 @@ public class VRFKeyPair implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.publicKey.close();
         this.secretKey.close();
     }

--- a/jni/src/main/java/com/horizen/vrfnative/VRFProof.java
+++ b/jni/src/main/java/com/horizen/vrfnative/VRFProof.java
@@ -67,7 +67,7 @@ public class VRFProof implements AutoCloseable
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     freeProof();
   }
 }

--- a/jni/src/main/java/com/horizen/vrfnative/VRFProveResult.java
+++ b/jni/src/main/java/com/horizen/vrfnative/VRFProveResult.java
@@ -25,7 +25,7 @@ public class VRFProveResult implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.vrfProof.close();
         this.vrfOutput.close();
     }

--- a/jni/src/main/java/com/horizen/vrfnative/VRFPublicKey.java
+++ b/jni/src/main/java/com/horizen/vrfnative/VRFPublicKey.java
@@ -79,7 +79,7 @@ public class VRFPublicKey implements AutoCloseable
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     freePublicKey();
   }
 }

--- a/jni/src/main/java/com/horizen/vrfnative/VRFSecretKey.java
+++ b/jni/src/main/java/com/horizen/vrfnative/VRFSecretKey.java
@@ -57,7 +57,7 @@ public class VRFSecretKey implements AutoCloseable
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         freeSecretKey();
     }
 }

--- a/jni/src/test/java/com/horizen/TestUtils.java
+++ b/jni/src/test/java/com/horizen/TestUtils.java
@@ -1,7 +1,6 @@
 package com.horizen;
 
 import com.google.common.io.BaseEncoding;
-import org.junit.Test;
 
 import static org.junit.Assert.*;
 
@@ -10,7 +9,8 @@ public class TestUtils {
     public static final int CERT_SEGMENT_SIZE = 1 << 15;
     public static final int CSW_SEGMENT_SIZE = 1 << 18;
 
-    private TestUtils() {}
+    private TestUtils() {
+    }
 
     public static byte[] fromHexString(String hex) {
         return BaseEncoding.base16().lowerCase().decode(hex.toLowerCase());

--- a/jni/src/test/java/com/horizen/certnative/NaiveThresholdSigProofTest.java
+++ b/jni/src/test/java/com/horizen/certnative/NaiveThresholdSigProofTest.java
@@ -68,16 +68,16 @@ public class NaiveThresholdSigProofTest {
     }
 
     @Test
-    public void testCreateVerifyRandomProofWithoutCustomFields() throws Exception {
+    public void testCreateVerifyRandomProofWithoutCustomFields() {
         testCreateVerifyRandomProof(0, snarkPkPathNoCustomFields, snarkVkPathNoCustomFields);
     }
 
     @Test
-    public void testCreateVerifyRandomProofWithCustomFields() throws Exception {
+    public void testCreateVerifyRandomProofWithCustomFields() {
         testCreateVerifyRandomProof(customFieldsNum, snarkPkPathCustomFields, snarkVkPathCustomFields);
     }
 
-    private void testCreateVerifyRandomProof(int numCustomFields, String snarkPkPath, String snarkVkPath) throws Exception {
+    private void testCreateVerifyRandomProof(int numCustomFields, String snarkPkPath, String snarkVkPath) {
         Random r = new Random();
 
         scId = FieldElement.createRandom();

--- a/jni/src/test/java/com/horizen/certnative/NaiveThresholdSignatureWKeyRotationProofTest.java
+++ b/jni/src/test/java/com/horizen/certnative/NaiveThresholdSignatureWKeyRotationProofTest.java
@@ -463,6 +463,16 @@ public class NaiveThresholdSignatureWKeyRotationProofTest {
             genesisKeyRootHash.freeFieldElement();
             genesisKeyRootHash = null;
         }
+        if (withdrawalCertificate != null) {
+            withdrawalCertificate.close();
+        }
+        if (prevValidatorsKeysRoot != null) {
+            withdrawalCertificate.close();
+        }
+        if (keysSignaturesList != null) {
+            keysSignaturesList.close();
+
+        }
     }
 
     @AfterClass

--- a/jni/src/test/java/com/horizen/certnative/WithdrawalCertificateTest.java
+++ b/jni/src/test/java/com/horizen/certnative/WithdrawalCertificateTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Random;
 
 import com.horizen.TestUtils;
-import com.horizen.librustsidechains.FieldElement;
-
 import org.junit.Test;
 
 public class WithdrawalCertificateTest {
@@ -21,27 +19,19 @@ public class WithdrawalCertificateTest {
     static int customFieldsCout = 10;
 
     @Test
-    public void testWCertFieldHash() throws Exception {
+    public void testWCertFieldHash() {
         assertEquals(expectedWCertNoBtNoCFFieldHashHex, generateWCertAndGetFieldHashHex(0, 0));
         assertEquals(expectedWCertWithBtWithCFFieldHashHex, generateWCertAndGetFieldHashHex(backwardTransferCout, customFieldsCout));
         assertEquals(expectedWCertNoBtWithCFFieldHashHex, generateWCertAndGetFieldHashHex(0, customFieldsCout));
         assertEquals(expectedWCertWithBtNoCFFieldHashHex, generateWCertAndGetFieldHashHex(backwardTransferCout, 0));
     }
 
-    private String generateWCertAndGetFieldHashHex(int numBt, int numCustomFields) throws Exception {
+    private String generateWCertAndGetFieldHashHex(int numBt, int numCustomFields) {
         
         // Generate random cert
         Random r = new Random(seed);
-        WithdrawalCertificate cert = WithdrawalCertificate.getRandom(r, numBt, numCustomFields);
-
-        // Get FieldHash
-        FieldElement certHash = cert.getHash();
-        byte[] certHashBytes = certHash.serializeFieldElement();
-
-        // Free memory Rust side
-        cert.close();
-        certHash.close();
-
-        return TestUtils.toHexString(certHashBytes);
+        try (WithdrawalCertificate cert = WithdrawalCertificate.getRandom(r, numBt, numCustomFields)) {
+            return TestUtils.toHexString(cert.getHashBytes());
+        }
     }
 }

--- a/jni/src/test/java/com/horizen/commitmenttreenative/CommitmentTreeTest.java
+++ b/jni/src/test/java/com/horizen/commitmenttreenative/CommitmentTreeTest.java
@@ -327,6 +327,38 @@ public class CommitmentTreeTest {
     }
 
     @Test
+    public void getScCommitmetCertPath() {
+        try (
+            CommitmentTree commTree = CommitmentTree.init();
+            FieldElement scId = FieldElement.createRandom();
+            FieldElement certLeaf = FieldElement.createRandom();
+        ) {
+            byte[] scIdBytes = scId.serializeFieldElement();
+            byte[] certHashBytes = certLeaf.serializeFieldElement();
+            commTree.addCertLeaf(scIdBytes, certHashBytes);
+
+            try (FieldElement scTxCommitmentRoot = commTree.getCommitment().get()) {
+                Optional<ScCommitmentCertPath> pathOpt = commTree.getScCommitmentCertPath(scIdBytes, certHashBytes);
+
+                assertTrue(pathOpt.isPresent());
+    
+                ScCommitmentCertPath path = pathOpt.get(); 
+                assertTrue(path.verify(scTxCommitmentRoot, scId, certLeaf));
+                path.close();
+    
+                // Sanity check
+                assertFalse(
+                    commTree.getScCommitmentCertPath(
+                        scIdBytes, 
+                        FieldElement.createRandom().serializeFieldElement()
+                        )
+                    .isPresent()
+                );
+            }
+        }
+    }
+
+    @Test
     public void existenceProofTest() {
         CommitmentTree commTree = CommitmentTree.init();
         byte[] scId = generateFieldElementBytes();

--- a/jni/src/test/java/com/horizen/commitmenttreenative/ScCommitmentCertPathTest.java
+++ b/jni/src/test/java/com/horizen/commitmenttreenative/ScCommitmentCertPathTest.java
@@ -1,0 +1,159 @@
+package com.horizen.commitmenttreenative;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.horizen.librustsidechains.FieldElement;
+
+public class ScCommitmentCertPathTest {
+    private ScCommitmentCertPath addCertAndReturnPath(CommitmentTree commTree, FieldElement scId, FieldElement certLeaf) {
+        byte[] scIdBytes = scId.serializeFieldElement();
+        byte[] certBytes = certLeaf.serializeFieldElement();
+        commTree.addCertLeaf(scIdBytes, certBytes);
+
+        return commTree.getScCommitmentCertPath(scIdBytes, certBytes).get();
+    }
+
+    @Test
+    public void validPath() {
+        try (
+                CommitmentTree ct = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf = FieldElement.createRandom();
+                ScCommitmentCertPath path = addCertAndReturnPath(ct, scId, certLeaf);
+                FieldElement root = ct.getCommitment().get();) {
+            assertTrue(path.verify(root, scId, certLeaf));
+        }
+    }
+
+    @Test
+    public void verifyShouldFailIfInvalidRoot() {
+        try (
+                CommitmentTree ct = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf = FieldElement.createRandom();
+                ScCommitmentCertPath path = addCertAndReturnPath(ct, scId, certLeaf);
+                FieldElement fakeRoot = FieldElement.createRandom();) {
+            assertFalse(path.verify(fakeRoot, scId, certLeaf));
+        }
+    }
+
+    @Test
+    public void verifyShouldFailIfInvalidScId() {
+        try (
+                CommitmentTree ct = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf = FieldElement.createRandom();
+                ScCommitmentCertPath path = addCertAndReturnPath(ct, scId, certLeaf);
+                FieldElement root = ct.getCommitment().get();
+                FieldElement fakeScId = FieldElement.createRandom();) {
+            assertFalse(path.verify(root, fakeScId, certLeaf));
+        }
+    }
+
+    @Test
+    public void verifyShouldFailIfInvalidCertHash() {
+        try (
+                CommitmentTree ct = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf = FieldElement.createRandom();
+                ScCommitmentCertPath path = addCertAndReturnPath(ct, scId, certLeaf);
+                FieldElement root = ct.getCommitment().get();
+                FieldElement fakeCertHash = FieldElement.createRandom();) {
+            assertFalse(path.verify(root, fakeCertHash, certLeaf));
+        }
+    }
+
+    @Test
+    public void generateScTxCommitmentRoot() {
+        try (
+                CommitmentTree ct = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf = FieldElement.createRandom();
+                ScCommitmentCertPath path = addCertAndReturnPath(ct, scId, certLeaf);
+                FieldElement root = ct.getCommitment().get();) {
+            assertEquals(root, path.apply(scId, certLeaf).get());
+        }
+    }
+
+    @Test
+    public void shouldSerializeDeserialize() {
+        try (
+                CommitmentTree ct = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf = FieldElement.createRandom();
+                ScCommitmentCertPath path = addCertAndReturnPath(ct, scId, certLeaf);
+                FieldElement root = ct.getCommitment().get();) {
+            /// Sanity Check
+            assertTrue(path.verify(root, scId, certLeaf));
+
+            byte[] serialized = path.serialize();
+
+            try (ScCommitmentCertPath deserialized = ScCommitmentCertPath.deserialize(serialized, true)) {
+                assertTrue(deserialized.verify(root, scId, certLeaf));
+            }
+
+            serialized[0] = (byte) (serialized[0] + 1);
+
+            try (ScCommitmentCertPath deserialized = ScCommitmentCertPath.deserialize(serialized, true)) {
+                assertFalse(deserialized.verify(root, scId, certLeaf));
+            }
+        }
+    }
+
+    @Test
+    public void completeTest() {
+        try (
+                CommitmentTree commTree = CommitmentTree.init();
+                FieldElement scId = FieldElement.createRandom();
+                FieldElement certLeaf0 = FieldElement.createRandom();
+                FieldElement certLeaf1 = FieldElement.createRandom();
+                FieldElement certLeaf2 = FieldElement.createRandom();) {
+            byte[] scIdBytes = scId.serializeFieldElement();
+            FieldElement[] certs = { certLeaf0, certLeaf1, certLeaf2 };
+            ArrayList<byte[]> certsHashBytes = Arrays.stream(certs)
+                    .map(FieldElement::serializeFieldElement)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            for (byte[] h : certsHashBytes) {
+                commTree.addCertLeaf(scIdBytes, h);
+            }
+
+            try (FieldElement scTxCommitmentRoot = commTree.getCommitment().get()) {
+                ArrayList<ScCommitmentCertPath> paths = certsHashBytes.stream().map(
+                        h -> commTree.getScCommitmentCertPath(scIdBytes, h).get())
+                        .collect(Collectors.toCollection(ArrayList::new));
+
+                assertFalse(
+                        commTree.getScCommitmentCertPath(scIdBytes, FieldElement.createRandom().serializeFieldElement())
+                                .isPresent());
+
+                for (int i = 0; i < certs.length; i++) {
+                    assertTrue(paths.get(i).verify(scTxCommitmentRoot, scId, certs[i]));
+                }
+                assertFalse(paths.get(0).verify(scTxCommitmentRoot, scId, FieldElement.createRandom()));
+                for (int i = 0; i < certs.length; i++) {
+                    assertFalse(paths.get(i).verify(FieldElement.createRandom(), scId, certs[i]));
+                }
+                for (int i = 0; i < certs.length; i++) {
+                    assertFalse(paths.get(i).verify(scTxCommitmentRoot, FieldElement.createRandom(), certs[i]));
+                }
+                for (int i = 0; i < certs.length; i++) {
+                    try (FieldElement root = paths.get(i).apply(scId, certs[i]).get()) {
+                        assertEquals(scTxCommitmentRoot, root);
+                    }
+                }
+                for (ScCommitmentCertPath path : paths) {
+                    path.freeScCommitmentCertPath();
+                }
+            }
+        }
+    }
+}

--- a/jni/src/test/java/com/horizen/cswnative/CswProofTest.java
+++ b/jni/src/test/java/com/horizen/cswnative/CswProofTest.java
@@ -72,7 +72,7 @@ public class CswProofTest {
     }
 
     @Test
-    public void testCreateVerifyScUtxoRandomProof() throws Exception {
+    public void testCreateVerifyScUtxoRandomProof() {
 
         // Compute scUtxo nullifier
         FieldElement nullifier = scUtxoOutput.getNullifier();
@@ -158,7 +158,7 @@ public class CswProofTest {
     }
 
     @Test
-    public void testCreateVerifyFwtRandomProof() throws Exception {
+    public void testCreateVerifyFwtRandomProof() {
         // Generate random receiver
         Random r = new Random(seed);
         byte[] receiver = new byte[Constants.MC_PK_HASH_SIZE()];
@@ -288,7 +288,7 @@ public class CswProofTest {
     }
 
     @AfterClass
-    public static void free() throws Exception {
+    public static void free() {
         wCert.close();
         // Delete proving keys and verification keys
         new File(snarkPkPath).delete();

--- a/jni/src/test/java/com/horizen/librustsidechains/FieldElementTest.java
+++ b/jni/src/test/java/com/horizen/librustsidechains/FieldElementTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class FieldElementTest {
 
     @Test
-    public void testRandomSerializeDeserialize() throws Exception {
+    public void testRandomSerializeDeserialize() {
 
         int samples = 100;
         for( int i = 0; i < samples; i++ ) {
@@ -45,7 +45,7 @@ public class FieldElementTest {
     }
 
     @Test
-    public void testSplitPositive() throws Exception {
+    public void testSplitPositive() {
         // Positive case
         for(int i = 1; i < Constants.FIELD_ELEMENT_LENGTH(); i++) {
             // Generate random FieldElement and split it into two FieldElements at index i
@@ -68,7 +68,7 @@ public class FieldElementTest {
     }
 
     @Test
-    public void testSplitNegative() throws Exception {
+    public void testSplitNegative() {
         // Split then rejoin at wrong index and assert we are not able to reconstruct the original FieldElement
         for(int i = 1; i < Constants.FIELD_ELEMENT_LENGTH() - 1; i++) {
             // Generate random FieldElement and split it into two FieldElements at index i
@@ -96,7 +96,7 @@ public class FieldElementTest {
     }
 
     @Test
-    public void testSplitExceptions() throws Exception {
+    public void testSplitExceptions() {
         FieldElement fe1 = FieldElement.createRandom();
         FieldElement fe2 = FieldElement.createRandom();
 

--- a/jni/src/test/java/com/horizen/poseidonnative/PoseidonHashTest.java
+++ b/jni/src/test/java/com/horizen/poseidonnative/PoseidonHashTest.java
@@ -27,7 +27,7 @@ public class PoseidonHashTest {
     }
 
     @Test
-    public void testReset() throws Exception {
+    public void testReset() {
 
         Random r = new Random(seed);
         FieldElement expectedHash = FieldElement.deserialize(TestUtils.fromHexString(expectedHashForReset));
@@ -51,7 +51,7 @@ public class PoseidonHashTest {
     }
 
     @Test
-    public void testComputeHashConstantLength() throws Exception {
+    public void testComputeHashConstantLength() {
 
         // Deserialize expected hash
         byte[] hashBytes = {
@@ -91,7 +91,7 @@ public class PoseidonHashTest {
     }
 
     @Test
-    public void testComputeHashVariableLength() throws Exception {
+    public void testComputeHashVariableLength() {
 
         // Deserialize expected hash
         byte[] hashBytes = {

--- a/jni/src/test/java/com/horizen/sc2scnative/Sc2ScTest.java
+++ b/jni/src/test/java/com/horizen/sc2scnative/Sc2ScTest.java
@@ -1,0 +1,290 @@
+package com.horizen.sc2scnative;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.horizen.TestUtils;
+import com.horizen.certnative.WithdrawalCertificate;
+import com.horizen.commitmenttreenative.CommitmentTree;
+import com.horizen.commitmenttreenative.CustomBitvectorElementsConfig;
+import com.horizen.commitmenttreenative.CustomFieldElementsConfig;
+import com.horizen.commitmenttreenative.ScCommitmentCertPath;
+import com.horizen.librustsidechains.Constants;
+import com.horizen.librustsidechains.FieldElement;
+import com.horizen.merkletreenative.InMemoryAppendOnlyMerkleTree;
+import com.horizen.merkletreenative.MerklePath;
+import com.horizen.provingsystemnative.ProvingSystem;
+import com.horizen.provingsystemnative.ProvingSystemType;
+
+public class Sc2ScTest {
+    private static int MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS = Constants.MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS();
+    private static int MSG_ROOT_HASH_CUSTOM_FIELDS_POS = Constants.MSG_ROOT_HASH_CUSTOM_FIELDS_POS();
+    private static int MIN_CUSTOM_FIELDS = Constants.MIN_CUSTOM_FIELDS();
+    private static int MSG_MT_HEIGHT = Constants.MSG_MT_HEIGHT();
+
+    static boolean zk = false;
+
+    static ProvingSystemType psType = ProvingSystemType.COBOUNDARY_MARLIN;
+    static int customFieldsNum = 3;
+    static String pkPath = "./test_sc2sc_pk";
+    static String vkPath = "./test_sc2sc_vk";
+
+    static int maxProofPlusVkSize = 9 * 1024;
+
+    private InMemoryAppendOnlyMerkleTree msgTree;
+    private CommitmentTree currentCt = CommitmentTree.init();
+    private CommitmentTree nextCt = CommitmentTree.init();
+    private WithdrawalCertificate currWithdrawalCertificate;
+    private WithdrawalCertificate nextWithdrawalCertificate;
+
+    @BeforeClass
+    public static void initKeys() throws Exception {
+        ProvingSystem.generateDLogKeys(psType, TestUtils.DLOG_KEYS_SIZE);
+        assertTrue(Sc2Sc.setup(psType, customFieldsNum, Optional.of(TestUtils.CERT_SEGMENT_SIZE),
+                pkPath, vkPath, zk, maxProofPlusVkSize));
+    }
+
+    @AfterClass
+    public static void deleteKeys() {
+        // Delete proving keys and verification keys
+        new File(pkPath).delete();
+        new File(vkPath).delete();
+    }
+
+    @Before
+    public void setUp() {
+        msgTree = InMemoryAppendOnlyMerkleTree.init(MSG_MT_HEIGHT, 1 << MSG_MT_HEIGHT);
+        currentCt = CommitmentTree.init();
+        nextCt = CommitmentTree.init();
+    }
+
+    @After
+    public void tearDown() {
+        msgTree.close();
+        currentCt.close();
+        nextCt.close();
+        if (nextWithdrawalCertificate != null) {
+            nextWithdrawalCertificate.close();
+        }
+        if (currWithdrawalCertificate != null) {
+            currWithdrawalCertificate.close();
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionIfPkSizeIsTooLarge() {
+        Exception ex = assertThrows(Exception.class, () -> {
+            Sc2Sc.setup(psType, customFieldsNum, Optional.of(TestUtils.CERT_SEGMENT_SIZE),
+                    pkPath, vkPath, zk, 1);
+        });
+        assertTrue(ex.getMessage().contains("Circuit is too complex"));
+    }
+
+    @Test
+    public void shouldUseTheGivenProvingSystemType() {
+        assertEquals(psType, ProvingSystem.getVerifierKeyProvingSystemType(vkPath));
+    }
+
+    @Test
+    public void provingKeyAndVerificationKeyShouldBeChoerent() {
+        assertEquals(ProvingSystem.getVerifierKeyProvingSystemType(vkPath),
+                ProvingSystem.getVerifierKeyProvingSystemType(pkPath));
+    }
+
+    @Test
+    public void shouldThrowExceptionIfWeUseNotEnoughCustomFields() {
+        Exception ex = assertThrows(Exception.class, () -> {
+            Sc2Sc.setup(psType, 1, Optional.of(TestUtils.CERT_SEGMENT_SIZE),
+                    pkPath, vkPath, zk, maxProofPlusVkSize);
+        });
+        assertTrue(ex.getMessage().contains("need at least"));
+    }
+
+    private byte[] generateRandomBytes(Random r, int len) {
+        byte[] bytes = new byte[len];
+        r.nextBytes(bytes);
+        return bytes;
+    }
+
+    private byte[] generateFieldRandomBytes(Random r) {
+        try (FieldElement f = FieldElement.createRandom(r)) {
+            return f.serializeFieldElement();
+        }
+    }
+
+    private void addRandomScc(Random r, CommitmentTree ct, byte[] scId) {
+        assertTrue(ct.addScCr(scId,
+                r.nextLong(),
+                generateFieldRandomBytes(r),
+                generateFieldRandomBytes(r),
+                r.nextInt(),
+                r.nextInt(),
+                (byte) r.nextInt(),
+                new CustomFieldElementsConfig[0],
+                new CustomBitvectorElementsConfig[0],
+                r.nextLong(),
+                r.nextLong(),
+                generateRandomBytes(r, 1024),
+                Optional.empty(),
+                generateRandomBytes(r, 2000),
+                Optional.empty()));
+    }
+
+    private byte[] root(CommitmentTree ct) {
+        try (FieldElement root = ct.getCommitment().get()) {
+            return root.serializeFieldElement();
+        }
+    }
+
+    private byte[] appendRandomMsgHash(Random r) {
+        try (FieldElement msgHash = FieldElement.createRandom(r)) {
+            msgTree.append(msgHash);
+            return msgHash.serializeFieldElement();
+        }
+    }
+
+    private MerklePath getMsgPath(int leafIndex) {
+        msgTree.finalizeTreeInPlace();
+        return msgTree.getMerklePath(leafIndex);
+    }
+
+    private byte[] getMsgRoot() {
+        msgTree.finalizeTreeInPlace();
+        try (FieldElement root = msgTree.root()) {
+            return root.serializeFieldElement();
+        }
+    }
+
+    @Test
+    public void happyPath() {
+        Random r = new Random();
+        RandomProofData proofData = generateRandomProof(r, 42);
+
+        assertNotNull("Proof creation must be successful", proofData.proof);
+
+        assertEquals(psType, ProvingSystem.getProofProvingSystemType(proofData.proof));
+
+        assertTrue(Sc2Sc.verifyProof(
+                proofData.nextScTxCommitmentsRoot,
+                proofData.currentScTxCommitmentsRoot,
+                proofData.msgHash,
+                proofData.proof,
+                vkPath));
+    }
+
+    private byte[] changeBytes(byte[] data) {
+        data[0] = (byte) (data[0] + 1);
+        return data;
+    }
+
+    @Test
+    public void shouldNotVerifyInvalidInput() {
+        Random r = new Random();
+        RandomProofData proofData = generateRandomProof(r, 42);
+
+        assertFalse(
+                Sc2Sc.verifyProof(
+                        changeBytes(proofData.nextScTxCommitmentsRoot),
+                        proofData.currentScTxCommitmentsRoot,
+                        proofData.msgHash,
+                        proofData.proof,
+                        vkPath));
+
+        assertFalse(
+                Sc2Sc.verifyProof(
+                        proofData.nextScTxCommitmentsRoot,
+                        changeBytes(proofData.currentScTxCommitmentsRoot),
+                        proofData.msgHash,
+                        proofData.proof,
+                        vkPath));
+        assertFalse(
+                Sc2Sc.verifyProof(
+                        proofData.nextScTxCommitmentsRoot,
+                        proofData.currentScTxCommitmentsRoot,
+                        changeBytes(proofData.msgHash),
+                        proofData.proof,
+                        vkPath));
+    }
+
+    // Generate a RandomProofData with just a a certificate for epoch and epoch + 1.
+    private RandomProofData generateRandomProof(Random r, int epoch) {
+        // We'll create tx commitment for a epoch with one certificate and
+        // another one for next epoch with another certificate. From this
+        // commitments we'll extract the path and then create a circuit.
+        byte[] scId = generateFieldRandomBytes(r);
+        byte[] msgHash = appendRandomMsgHash(r);
+        byte[] msgRoot = getMsgRoot();
+
+        WithdrawalCertificate currWithdrawalCertificate = WithdrawalCertificate.getRandom(
+                r, 0, MIN_CUSTOM_FIELDS);
+        currWithdrawalCertificate.setScId(scId);
+        currWithdrawalCertificate.setEpochNumber(epoch);
+
+        currWithdrawalCertificate.setCustomField(MSG_ROOT_HASH_CUSTOM_FIELDS_POS, msgRoot);
+        byte[] currCertHash = currWithdrawalCertificate.getHashBytes();
+
+        addRandomScc(r, currentCt, scId);
+        currentCt.addCertLeaf(scId, currCertHash);
+
+        byte[] currentScTxCommitmentsRoot = root(currentCt);
+
+        WithdrawalCertificate nextWithdrawalCertificate = WithdrawalCertificate.getRandom(
+                r, 0, MIN_CUSTOM_FIELDS);
+        nextWithdrawalCertificate.setScId(scId);
+        nextWithdrawalCertificate.setEpochNumber(epoch + 1);
+
+        nextWithdrawalCertificate.setCustomField(MAX_QUALITY_CERT_HASH_CUSTOM_FIELDS_POS, currCertHash);
+        byte[] nextCertHash = nextWithdrawalCertificate.getHashBytes();
+
+        addRandomScc(r, nextCt, scId);
+        nextCt.addCertLeaf(scId, nextCertHash);
+        byte[] nextScTxCommitmentsRoot = root(nextCt);
+
+        try (
+                ScCommitmentCertPath currentPath = currentCt.getScCommitmentCertPath(scId, currCertHash).get();
+                ScCommitmentCertPath nextPath = nextCt.getScCommitmentCertPath(scId, nextCertHash).get();
+                MerklePath msgPath = getMsgPath(0);) {
+            byte[] proof = Sc2Sc.createProof(
+                    nextScTxCommitmentsRoot,
+                    currentScTxCommitmentsRoot,
+                    msgHash,
+                    nextWithdrawalCertificate,
+                    currWithdrawalCertificate,
+                    nextPath,
+                    currentPath,
+                    msgPath,
+                    pkPath,
+                    Optional.of(TestUtils.CERT_SEGMENT_SIZE),
+                    zk);
+            return new RandomProofData(nextScTxCommitmentsRoot, currentScTxCommitmentsRoot, msgHash, proof);
+        }
+    }
+
+    private static class RandomProofData {
+        public byte[] nextScTxCommitmentsRoot;
+        public byte[] currentScTxCommitmentsRoot;
+        public byte[] msgHash;
+
+        public byte[] proof;
+
+        public RandomProofData(byte[] nextScTxCommitmentsRoot, byte[] currentScTxCommitmentsRoot,
+                byte[] msgHash, byte[] proof) {
+            this.nextScTxCommitmentsRoot = nextScTxCommitmentsRoot;
+            this.currentScTxCommitmentsRoot = currentScTxCommitmentsRoot;
+            this.msgHash = msgHash;
+            this.proof = proof;
+        }
+    }
+}

--- a/jni/src/test/java/com/horizen/schnorrnative/SchnorrKeyPairTest.java
+++ b/jni/src/test/java/com/horizen/schnorrnative/SchnorrKeyPairTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
 public class SchnorrKeyPairTest {
 
     @Test
-    public void testGenerate() throws Exception {
+    public void testGenerate() {
 
         try(SchnorrKeyPair keyPair = SchnorrKeyPair.generate())
         {
@@ -18,7 +18,7 @@ public class SchnorrKeyPairTest {
     }
 
     @Test
-    public void testDeriveFromSeed() throws Exception {
+    public void testDeriveFromSeed() {
         byte[] seed = { 1, 2, 3, 4, 5, 6, 7, 8 };
         byte[] expectedPubKeyBytes = {83, -1, 54, 52, 44, -74, -36, 113, 87, -126, 80, -84, -45, -116, 88, -69, 73, 118, -54, 100, 112, 80, 22, 64, 87, -93, 79, 2, -86, -48, 107, 31, 0};
         byte[] expectedSecretKeyBytes = {41, 70, -14, -11, 47, 124, 108, -114, -83, -97, 44, -44, 54, 63, -98, 6, 45, 45, 40, 5, 85, -37, 98, 59, -100, 77, -90, -61, -123, -50, -16, 13};
@@ -39,7 +39,7 @@ public class SchnorrKeyPairTest {
     }
 
     @Test
-    public void testSignVerify() throws Exception {
+    public void testSignVerify() {
 
         byte[] skBytes = {
             -75, 35, 36, 5, -30, -110, 63, 101, -39, 39, 46, 84, 51, -93, -9, 15, 54, -66, -122, -27, -47, 79, 63, -127,
@@ -73,7 +73,7 @@ public class SchnorrKeyPairTest {
     }
 
     @Test
-    public void testRandomSignVerify() throws Exception {
+    public void testRandomSignVerify() {
 
         int samples = 100;
 

--- a/jni/src/test/java/com/horizen/schnorrnative/SchnorrPublicKeyTest.java
+++ b/jni/src/test/java/com/horizen/schnorrnative/SchnorrPublicKeyTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
 public class SchnorrPublicKeyTest {
 
     @Test
-    public void testGetHash() throws Exception {
+    public void testGetHash() {
         byte[] seed = { 1, 2, 3, 4, 5, 6, 7, 8 };
         byte[] expected = {-37, -55, 0, -12, 70, 91, 97, -85, 12, 76, -8, 66, -7, 90, -75, -15, -66, 91, -65, 111, 6, 104, 20, -20, -54, -61, 67, 78, 88, -54, 84, 30 };
 

--- a/jni/src/test/java/com/horizen/schnorrnative/SchnorrSecretKeyTest.java
+++ b/jni/src/test/java/com/horizen/schnorrnative/SchnorrSecretKeyTest.java
@@ -10,7 +10,7 @@ public class SchnorrSecretKeyTest {
 
 
     @Test
-    public void testRandomKey() throws Exception {
+    public void testRandomKey() {
 
         int samples = 100;
         for(int i = 0; i < samples; i++) {

--- a/jni/src/test/java/com/horizen/vrfnative/VRFKeyPairTest.java
+++ b/jni/src/test/java/com/horizen/vrfnative/VRFKeyPairTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
 public class VRFKeyPairTest {
 
     @Test
-    public void testGenerate() throws Exception {
+    public void testGenerate() {
 
         try(VRFKeyPair keyPair = VRFKeyPair.generate())
         {
@@ -19,7 +19,7 @@ public class VRFKeyPairTest {
     }
 
     @Test
-    public void testDeriveFromSeed() throws Exception {
+    public void testDeriveFromSeed() {
         byte[] seed = { 1, 2, 3, 4, 5, 6, 7, 8 };
         byte[] expectedPubKeyBytes = {-41, 6, 40, 40, 18, 36, 100, -72, -107, 103, 60, -47, 40, -5, -119, 103, 89, 31, 82, 66, -98, 103, -128, 57, -116, -108, 81, -33, -8, -101, -95, 14, 0};
         byte[] expectedSecretKeyBytes = {-104, -120, -125, 121, 24, -25, -109, -49, -98, 17, -91, 15, 27, 14, 16, -54, 123, 57, 79, -88, 0, -82, -17, 72, -74, -109, 77, 66, 7, 113, 104, 62};
@@ -39,7 +39,7 @@ public class VRFKeyPairTest {
     }
 
     @Test
-    public void testProveVerify() throws Exception {
+    public void testProveVerify() {
 
         byte[] skBytes = {
                 -98, -107, -105, 70, 63, -92, -96, -24, 74, 29, 13, 80, 120, -45, 11, 125, 40, 52, 50, -92, -55, -35,
@@ -89,7 +89,7 @@ public class VRFKeyPairTest {
     }
 
     @Test
-    public void testRandomProveVerify() throws Exception {
+    public void testRandomProveVerify() {
         int samples = 100;
 
         for(int i = 0; i < samples; i++) {

--- a/jni/src/test/java/com/horizen/vrfnative/VRFSecretKeyTest.java
+++ b/jni/src/test/java/com/horizen/vrfnative/VRFSecretKeyTest.java
@@ -9,7 +9,7 @@ import com.horizen.librustsidechains.Constants;
 public class VRFSecretKeyTest {
 
     @Test
-    public void testRandomKey() throws Exception {
+    public void testRandomKey() {
 
         int samples = 100;
 

--- a/ouroboros/Cargo.toml
+++ b/ouroboros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouroboros"
-version = "0.7.0"
+version = "0.8.0-SNAPSHOT"
 authors = ["DanieleDiBenedetto <daniele@horizenlabs.io>"]
 edition = "2018"
 


### PR DESCRIPTION
This circuit follow the specifications in [ZenIP-42205](https://github.com/HorizenOfficial/ZenIPs/tree/draft/42205) and tests use `cctp_primitives::commitment_tree::CommitmentTree` to build a valid states tree.

BTW I did a little refactor to reuse some utilities in tests from other circuits. I've introduced some structs to simplify the tests for this circuit but I avoided to refactor the other circuits tests and use the newer utilities ... That can be done later in another PR if we prefer.