### PR TITLE
Add ScCommitmentCertPath.updateScCommitmentPath()

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6028,9 +6028,9 @@ ffi_export!(
         path: JObject,
         sc_commitment_path: JObject,
     ) -> jboolean {
-        let path: &mut ScCommitmentCertPath = dbg!(path).as_native_ref_mut_unchecked(env);
+        let path: &mut ScCommitmentCertPath = path.as_native_ref_mut_unchecked(env);
         let sc_commitment_path: &GingerMHTPath =
-            dbg!(sc_commitment_path).as_native_ref_unchecked(env);
+            sc_commitment_path.as_native_ref_unchecked(env);
 
         match sc_commitment_path
             .clone()

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -50,7 +50,7 @@ use demo_circuit::{
     type_mapping::*,
 };
 
-use jni_wrapper::{AsNativeRefMut, AsNativeRef, JNINativeWrapper};
+use jni_wrapper::{AsNativeRef, AsNativeRefMut, JNINativeWrapper};
 use primitives::{
     bytes_to_bits, signature::schnorr::field_based_schnorr::FieldBasedSchnorrPk, FieldBasedHash,
     FieldBasedMerkleTree, FieldBasedMerkleTreePath, FieldBasedSparseMerkleTree, FieldHasher,
@@ -5889,8 +5889,7 @@ ffi_export!(
         ) {
             Ok(proof) => {
                 //Return proof serialized
-                env
-                    .byte_array_from_slice(proof.as_slice())
+                env.byte_array_from_slice(proof.as_slice())
                     .expect("Should be able to convert Rust slice into jbytearray")
             }
             Err(e) => {
@@ -5916,7 +5915,6 @@ ffi_export!(
         check_vk: jboolean,
         compressed_vk: jboolean,
     ) -> jboolean {
-
         let next_sc_tx_commitments_root: &FieldElement =
             next_sc_tx_commitments_root.as_native_ref_unchecked(env);
         let curr_sc_tx_commitments_root: &FieldElement =
@@ -6020,6 +6018,32 @@ ffi_export!(
             JNI_TRUE
         } else {
             JNI_FALSE
+        }
+    }
+);
+
+ffi_export!(
+    fn Java_com_horizen_commitmenttreenative_ScCommitmentCertPath_nativeUpdateScCommitmentPath(
+        env: JNIEnv,
+        path: JObject,
+        sc_commitment_path: JObject,
+    ) -> jboolean {
+        let path: &mut ScCommitmentCertPath = dbg!(path).as_native_ref_mut_unchecked(env);
+        let sc_commitment_path: &GingerMHTPath =
+            dbg!(sc_commitment_path).as_native_ref_unchecked(env);
+
+        match sc_commitment_path
+            .clone()
+            .try_into()
+            .and_then(|p| path.update_sc_commitment_path(p).into())
+        {
+            Ok(_) => JNI_TRUE,
+            Err(e) => throw!(
+                &env,
+                "java/lang/IllegalArgumentException",
+                format!("Cannot update path: {:?}", e).as_str(),
+                JNI_FALSE
+            ),
         }
     }
 );

--- a/demo-circuit/src/sc2sc/mod.rs
+++ b/demo-circuit/src/sc2sc/mod.rs
@@ -348,6 +348,21 @@ impl ScCommitmentCertPath {
         )
         .into())
     }
+
+    pub fn update_sc_commitment_path(
+        &mut self,
+        sc_commitment_path: GingerMHTBinaryPath,
+    ) -> Result<(), Error> {
+        let length = sc_commitment_path.get_length();
+        if length != CMT_MT_HEIGHT {
+            Err(format!(
+                "Invalid path length {} != {} [height of the tree]",
+                length, CMT_MT_HEIGHT
+            ))?
+        }
+        self.sc_commitment_path = sc_commitment_path;
+        Ok(())
+    }
 }
 
 impl SemanticallyValid for ScCommitmentCertPath {

--- a/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
@@ -94,8 +94,8 @@ public class ScCommitmentCertPath implements AutoCloseable {
     /**
      * Update the path from the sidechain tx root to the commitment root
      * 
-     * @param path The new merkele path from the sdichain root to the commitment root
-     * @throws IllegalArgumentException if the given merkle path is not valid (wrong lenght)
+     * @param path The new merkle path from the sidechain root to the commitment root
+     * @throws IllegalArgumentException if the given merkle path is not valid (wrong length)
      */
     public void updateScCommitmentPath(MerklePath path) throws IllegalArgumentException{
         nativeUpdateScCommitmentPath(path);

--- a/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
+++ b/jni/src/main/java/com/horizen/commitmenttreenative/ScCommitmentCertPath.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import com.horizen.librustsidechains.FieldElement;
 import com.horizen.librustsidechains.Library;
+import com.horizen.merkletreenative.MerklePath;
 
 /*
  * This class represent a path from the certificate to the root of side chain
@@ -86,5 +87,17 @@ public class ScCommitmentCertPath implements AutoCloseable {
         if (scCommitmentCertPathPointer == 0) {
             throw new IllegalStateException("Field element was freed.");
         }
+    }
+
+    private native boolean nativeUpdateScCommitmentPath(MerklePath correctScPath) throws IllegalArgumentException;
+
+    /**
+     * Update the path from the sidechain tx root to the commitment root
+     * 
+     * @param path The new merkele path from the sdichain root to the commitment root
+     * @throws IllegalArgumentException if the given merkle path is not valid (wrong lenght)
+     */
+    public void updateScCommitmentPath(MerklePath path) throws IllegalArgumentException{
+        nativeUpdateScCommitmentPath(path);
     }
 }

--- a/jni/src/test/java/com/horizen/commitmenttreenative/ScCommitmentCertPathTest.java
+++ b/jni/src/test/java/com/horizen/commitmenttreenative/ScCommitmentCertPathTest.java
@@ -193,15 +193,15 @@ public class ScCommitmentCertPathTest {
             try (
                     FieldElement expectedScTxCommitmentRoot = commTreeReal.getCommitment().get();
                     MerklePath correctScPath = commTreeReal.getScCommitmentMerklePath(scId1Bytes).get();
-                    CommitmentTree commTreeFake = CommitmentTree.init();) {
+                    CommitmentTree commTreePartial = CommitmentTree.init();) {
                 for (byte[] h : certs1HashBytes) {
-                    commTreeFake.addCertLeaf(scId1Bytes, h);
+                    commTreePartial.addCertLeaf(scId1Bytes, h);
                 }
 
                 try (
-                        ScCommitmentCertPath pathCert1 = commTreeFake
+                        ScCommitmentCertPath pathCert1 = commTreePartial
                                 .getScCommitmentCertPath(scId1Bytes, certs1HashBytes.get(0)).get();
-                        ScCommitmentCertPath pathCert2 = commTreeFake
+                        ScCommitmentCertPath pathCert2 = commTreePartial
                                 .getScCommitmentCertPath(scId1Bytes, certs1HashBytes.get(1)).get();) {
                     assertFalse(pathCert1.verify(expectedScTxCommitmentRoot, scId1, certLeaf11));
                     assertFalse(pathCert2.verify(expectedScTxCommitmentRoot, scId1, certLeaf12));

--- a/jni/src/test/java/com/horizen/commitmenttreenative/ScCommitmentCertPathTest.java
+++ b/jni/src/test/java/com/horizen/commitmenttreenative/ScCommitmentCertPathTest.java
@@ -2,6 +2,7 @@ package com.horizen.commitmenttreenative;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -11,9 +12,12 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 
 import com.horizen.librustsidechains.FieldElement;
+import com.horizen.merkletreenative.InMemoryAppendOnlyMerkleTree;
+import com.horizen.merkletreenative.MerklePath;
 
 public class ScCommitmentCertPathTest {
-    private ScCommitmentCertPath addCertAndReturnPath(CommitmentTree commTree, FieldElement scId, FieldElement certLeaf) {
+    private ScCommitmentCertPath addCertAndReturnPath(CommitmentTree commTree, FieldElement scId,
+            FieldElement certLeaf) {
         byte[] scIdBytes = scId.serializeFieldElement();
         byte[] certBytes = certLeaf.serializeFieldElement();
         commTree.addCertLeaf(scIdBytes, certBytes);
@@ -152,6 +156,92 @@ public class ScCommitmentCertPathTest {
                 }
                 for (ScCommitmentCertPath path : paths) {
                     path.freeScCommitmentCertPath();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void updatePath() {
+        try (
+                CommitmentTree commTreeReal = CommitmentTree.init();
+                FieldElement scId1 = FieldElement.createFromLong(10);
+                FieldElement scId2 = FieldElement.createFromLong(20);
+                FieldElement certLeaf11 = FieldElement.createRandom();
+                FieldElement certLeaf12 = FieldElement.createRandom();
+                FieldElement certLeaf21 = FieldElement.createRandom();) {
+
+            byte[] scId1Bytes = scId1.serializeFieldElement();
+            byte[] scId2Bytes = scId2.serializeFieldElement();
+            FieldElement[] certs1 = { certLeaf11, certLeaf12 };
+            FieldElement[] certs2 = { certLeaf21 };
+            ArrayList<byte[]> certs1HashBytes = Arrays.stream(certs1)
+                    .map(FieldElement::serializeFieldElement)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            ArrayList<byte[]> certs2HashBytes = Arrays.stream(certs2)
+                    .map(FieldElement::serializeFieldElement)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            for (byte[] h : certs1HashBytes) {
+                commTreeReal.addCertLeaf(scId1Bytes, h);
+            }
+            for (byte[] h : certs2HashBytes) {
+                commTreeReal.addCertLeaf(scId2Bytes, h);
+            }
+
+            try (
+                    FieldElement expectedScTxCommitmentRoot = commTreeReal.getCommitment().get();
+                    MerklePath correctScPath = commTreeReal.getScCommitmentMerklePath(scId1Bytes).get();
+                    CommitmentTree commTreeFake = CommitmentTree.init();) {
+                for (byte[] h : certs1HashBytes) {
+                    commTreeFake.addCertLeaf(scId1Bytes, h);
+                }
+
+                try (
+                        ScCommitmentCertPath pathCert1 = commTreeFake
+                                .getScCommitmentCertPath(scId1Bytes, certs1HashBytes.get(0)).get();
+                        ScCommitmentCertPath pathCert2 = commTreeFake
+                                .getScCommitmentCertPath(scId1Bytes, certs1HashBytes.get(1)).get();) {
+                    assertFalse(pathCert1.verify(expectedScTxCommitmentRoot, scId1, certLeaf11));
+                    assertFalse(pathCert2.verify(expectedScTxCommitmentRoot, scId1, certLeaf12));
+
+                    pathCert1.updateScCommitmentPath(correctScPath);
+                    pathCert2.updateScCommitmentPath(correctScPath);
+
+                    assertTrue(pathCert1.verify(expectedScTxCommitmentRoot, scId1, certLeaf11));
+                    assertTrue(pathCert2.verify(expectedScTxCommitmentRoot, scId1, certLeaf12));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void updatePathShouldThrowExceptionIfWrongLength() {
+        try (
+                CommitmentTree commTree = CommitmentTree.init();
+                FieldElement scId = FieldElement.createFromLong(10);
+                FieldElement certLeaf = FieldElement.createRandom();
+                ) {
+
+            byte[] scIdBytes = scId.serializeFieldElement();
+            byte[] certLeafBytes = scId.serializeFieldElement();
+
+            commTree.addCertLeaf(scIdBytes, certLeafBytes);
+
+            try (
+                ScCommitmentCertPath pathCert = commTree
+                                .getScCommitmentCertPath(scIdBytes, certLeafBytes).get();
+                InMemoryAppendOnlyMerkleTree mt = InMemoryAppendOnlyMerkleTree.init(5, 1 << 5);
+                FieldElement leaf = FieldElement.createRandom();
+             ) {
+                mt.append(leaf);
+                mt.finalizeTreeInPlace();
+                try (MerklePath invalidPath = mt.getMerklePath(0)) {
+                    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+                        pathCert.updateScCommitmentPath(invalidPath);
+                    });
+                    assertTrue("'" + ex.getMessage() + "\' Not contains 'invalid path length'", ex.getMessage().toLowerCase().contains("invalid path length"));
                 }
             }
         }


### PR DESCRIPTION
Add ScCommitmentCertPath.updateScCommitmentPath() to handle the case where sdk can just rebuilt the sidechain tree but not the complete commitment tree.

