### PR TITLE
Replace unwrap with errors when possible

### DIFF
--- a/api/src/cctp_calls.rs
+++ b/api/src/cctp_calls.rs
@@ -187,7 +187,9 @@ fn get_naive_threshold_sig_circuit_prover_data(
 ) -> Result<(NaiveThresholdSignature, u64), Error> {
     //Get max pks
     let max_pks = pks.len();
-    assert_eq!(sigs.len(), max_pks);
+    if max_pks != sigs.len() {
+        Err("number of public keys different from number of signatures")?
+    }
 
     // Compute msg to sign
     let (mr_bt, msg) = compute_msg_to_sign(
@@ -840,7 +842,7 @@ pub fn vrf_prove(
     )?;
 
     //Convert gamma from proof to field elements
-    let gamma_coords = proof.gamma.to_field_elements().unwrap();
+    let gamma_coords = proof.gamma.to_field_elements()?;
 
     //Compute VRF output
     let output = {

--- a/demo-circuit/src/blaze_csw/constraints/data_structures.rs
+++ b/demo-circuit/src/blaze_csw/constraints/data_structures.rs
@@ -151,7 +151,8 @@ impl FieldHasherGadget<FieldHash, FieldElement, FieldHashGadget> for CswUtxoOutp
     ) -> Result<FieldElementGadget, SynthesisError> {
         // Initialize hash_input with personalization manually as we don't have, for now, hash gadget accepting personalization
         // (https://github.com/HorizenOfficial/ginger-lib/issues/78)
-        let personalization = personalization.unwrap();
+        let personalization = personalization.ok_or(
+            SynthesisError::Other("non-empty personalization required".to_string()))?;
         debug_assert!(personalization.len() == 1);
 
         // Add padding 1
@@ -530,9 +531,8 @@ impl ToConstraintFieldGadget<FieldElement> for CswFtOutputDataGadget {
             .enumerate()
             .map(|(index, chunk)| {
                 FieldElementGadget::from_bits(cs.ns(|| format!("FT from bits {}", index)), chunk)
-                    .unwrap()
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
 
         Ok(elements)
     }

--- a/demo-circuit/src/blaze_csw/mod.rs
+++ b/demo-circuit/src/blaze_csw/mod.rs
@@ -187,7 +187,7 @@ pub fn convert_te_pk_to_sw_pk(
 
     // Extract the public key bytes as Y coordinate
     let x_coordinate = sw_pk.x;
-    let mut pk_bytes = serialize_to_buffer(&x_coordinate, None).unwrap();
+    let mut pk_bytes = serialize_to_buffer(&x_coordinate, None)?;
 
     // Use the last (null) bit of the public key to store the sign of the X coordinate
     // Before this operation, the last bit of the public key (Y coordinate) is always 0 due to the field modulus

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/constraints/data_structures.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/constraints/data_structures.rs
@@ -398,7 +398,7 @@ impl AllocGadget<ValidatorKeysUpdates, FieldElement> for ValidatorKeysUpdatesGad
             updated_signing_keys_mk_signatures_g,
             updated_master_keys_sk_signatures_g,
             updated_master_keys_mk_signatures_g,
-            max_pks: max_pks.unwrap(),
+            max_pks: max_pks?,
         };
 
         Ok(new_instance)

--- a/demo-circuit/src/naive_threshold_sig_w_key_rotation/data_structures.rs
+++ b/demo-circuit/src/naive_threshold_sig_w_key_rotation/data_structures.rs
@@ -154,7 +154,7 @@ impl ValidatorKeysUpdates {
     pub(crate) fn get_key_hash(
         pk: &FieldBasedSchnorrPk<G2Projective>,
     ) -> Result<FieldElement, Error> {
-        let spk_fe = pk.0.to_field_elements().unwrap();
+        let spk_fe = pk.0.to_field_elements()?;
         let mut h = FieldHash::init_constant_length(spk_fe.len(), None);
         spk_fe.into_iter().for_each(|fe| {
             h.update(fe);


### PR DESCRIPTION
This PR aims at improving error handling by avoiding unnecessary `unwrap` operations anytime it is possible and convenient to return an error to the caller.